### PR TITLE
feat(export): supporting container images

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -6,44 +6,64 @@ on:
         description: node-version to execute the export
         type: string
         required: false
-        default: '18.x'
+        default: "18.x"
       janus-cli-version:
         description: Version of the janus-idp/cli package.
         type: string
         required: false
-        default: '^1.8.5'
+        default: "^1.19.1"
 
       plugins-repo:
-        description: Name of the repository that contains the backstage plugins to be exported as dynamic. For example backstage/backstage.  
+        description:
+          Name of the repository that contains the backstage plugins to be exported as dynamic. For example
+          backstage/backstage.
         type: string
         required: true
       plugins-repo-ref:
-        description: Git ref (tag, branch or SHA) of the repository that contains the backstage plugins to be exported as dynamic. For example backstage/backstage.  
+        description:
+          Git ref (tag, branch or SHA) of the repository that contains the backstage plugins to be exported as dynamic.
+          For example backstage/backstage.
         type: string
         required: true
       plugins-root:
-        description: Monorepo root relative folder, in the repository that contains the backstage plugins to be exported as dynamic.  
+        description:
+          Monorepo root relative folder, in the repository that contains the backstage plugins to be exported as
+          dynamic.
         required: false
         type: string
-        default: ''
-  
+        default: ""
+
       overlay-repo:
-        description: Name of the repository that contains the list of backstage plugins to be exported as dynamic, as well as optional export directives and source overlays.
+        description:
+          Name of the repository that contains the list of backstage plugins to be exported as dynamic, as well as
+          optional export directives and source overlays.
         required: true
         type: string
       overlay-repo-ref:
-        description: Git ref (tag, branch or SHA) of the repository that contains the list of backstage plugins to be exported as dynamic, as well as optional export directives and source overlays.
+        description:
+          Git ref (tag, branch or SHA) of the repository that contains the list of backstage plugins to be exported as
+          dynamic, as well as optional export directives and source overlays.
         type: string
         required: true
 
+      publish-container:
+        description: Publish a container image for the dynamic plugins
+        type: boolean
+        default: false
+        required: false
+
       publish-release-assets:
-        description: Whether the dynamic plugin archives should be published as GitHub release assets or pushed as workflow artifacts.
+        description:
+          Whether the dynamic plugin archives should be published as GitHub release assets or pushed as workflow
+          artifacts.
         required: false
         type: boolean
         default: ${{ github.ref_type == 'tag' && github.event_name == 'push' }}
 
       artifact-retention-days:
-        description: Number of days the dynamic plugin archives will be kept as a workflow artifact (if not published as release assets).
+        description:
+          Number of days the dynamic plugin archives will be kept as a workflow artifact (if not published as release
+          assets).
         required: false
         type: number
         default: 1
@@ -53,21 +73,23 @@ on:
         required: false
         type: boolean
         default: false
-  
+
 jobs:
-  export:    
+  export:
     runs-on: ubuntu-latest
 
     env:
       NODE_OPTIONS: --max-old-space-size=8192
-    
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ github.token }}
+
     defaults:
       run:
         working-directory: ${{ inputs.plugins-root }}
 
     name: Export
     steps:
-
       - name: Checkout plugins repository ${{ inputs.plugins-repo }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         if: ${{ inputs.plugins-root == '' }}
@@ -111,15 +133,41 @@ jobs:
       - name: Run Typescript type checking
         run: yarn tsc
 
+      - name: Install Podman
+        if: ${{ inputs.publish-container }}
+        uses: gacts/install-podman@v1.1.1
+
+      - name: Log in to container registry
+        if: ${{ inputs.publish-container }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Set Plugin Base Image Name
+        id: set-image-tag-name
+        shell: bash
+        run: |
+          BASE_IMAGE_TAG_NAME=""
+          if [[ "${{ inputs.publish-container  }}" ]]
+          then
+            BASE_IMAGE_TAG_NAME="${{ env.IMAGE_REGISTRY }}"
+          else
+            echo "Not publish container image with plugin content"
+          fi
+          echo "BASE_IMAGE_TAG_NAME=$BASE_IMAGE_TAG_NAME" >> $GITHUB_OUTPUT
+
       - name: Export dynamic plugin packages
-        if: ${{ success() }} 
-        id: export-dynamic 
+        if: ${{ success() }}
+        id: export-dynamic
         uses: redhat-developer/rhdh-plugin-export-utils/export-dynamic@main
         with:
-            plugins-root: ${{inputs.plugins-root}}
-            plugins-file: ${{ github.workspace }}/overlay-repo/${{inputs.plugins-root}}/plugins-list.yaml
-            destination: ${{ github.workspace }}/dynamic-plugin-archives
-            janus-cli-version: ${{inputs.janus-cli-version}}
+          plugins-root: ${{inputs.plugins-root}}
+          plugins-file: ${{ github.workspace }}/overlay-repo/${{inputs.plugins-root}}/plugins-list.yaml
+          destination: ${{ github.workspace }}/dynamic-plugin-archives
+          janus-cli-version: ${{inputs.janus-cli-version}}
+          base-image-tag-name: ${{ steps.set-image-tag-name.outputs.BASE_IMAGE_TAG_NAME }}
 
       - name: Set artifacts name suffix
         id: set-artifacts-name-suffix
@@ -131,30 +179,30 @@ jobs:
             ARTIFACTS_NAME_SUFFIX=" ($(echo '${{  inputs.plugins-root }}' | sed -e 's:/:-:g'))"
           fi
           echo "ARTIFACTS_NAME_SUFFIX=$ARTIFACTS_NAME_SUFFIX" >> $GITHUB_OUTPUT
-    
+
       - name: Upload exported archives to workflow artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !inputs.publish-release-assets && success() }}
         with:
-            name: dynamic plugin packages${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
-            path: ${{ github.workspace }}/dynamic-plugin-archives
-            if-no-files-found: warn
-            retention-days: ${{ inputs.artifact-retention-days }}
-            overwrite: true
+          name: dynamic plugin packages${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
+          path: ${{ github.workspace }}/dynamic-plugin-archives
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
+          overwrite: true
 
       - name: Upload the project to workflow artifacts on failure
         uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-project-on-error && (failure() || steps.export-dynamic.outputs.errors) }}
         with:
-            name: project root folder${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
-            path: |
-              ${{ github.workspace }}
-              !${{ github.workspace }}/dynamic-plugin-archives
-              !${{ github.workspace }}/node_modules
-            if-no-files-found: warn
-            retention-days: ${{ inputs.artifact-retention-days }}
-            overwrite: true
-    
+          name: project root folder${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
+          path: |
+            ${{ github.workspace }}
+            !${{ github.workspace }}/dynamic-plugin-archives
+            !${{ github.workspace }}/node_modules
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
+          overwrite: true
+
       - name: Check export errors
         if: ${{ success() && steps.export-dynamic.outputs.errors != '' }}
         uses: actions/github-script@v3
@@ -166,7 +214,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: ${{ success() && inputs.publish-release-assets }}
         with:
-            body:
-              Dynamic Plugins for Red Hat Developer Hub ${{ github.ref_name }}, exported from ${{ inputs.plugins-repo }}.
-            files: ${{ github.workspace }}/dynamic-plugin-archives/*
-            repository: ${{ github.repository }}
+          body:
+            Dynamic Plugins for Red Hat Developer Hub ${{ github.ref_name }}, exported from ${{ inputs.plugins-repo }}.
+          files: ${{ github.workspace }}/dynamic-plugin-archives/*
+          repository: ${{ github.repository }}

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -37,6 +37,13 @@ on:
         required: false
         default: ''
 
+      publish-container:
+        description: Publish a container image for the dynamic plugins
+        required: false
+        type: boolean
+        default: false
+
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -148,6 +155,10 @@ jobs:
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
       upload-project-on-error: ${{ inputs.upload-project-on-error == 'true' }}
+      publish-container: ${{ inputs.publish-container }}
 
     permissions:
       contents: write
+      packages: write
+      attestations: write
+      id-token: write

--- a/export-dynamic/action.yaml
+++ b/export-dynamic/action.yaml
@@ -6,7 +6,9 @@ inputs:
     required: true
 
   plugins-file:
-    description: Absolute path of the file that contains a yaml dictionary of plugin relative paths to export as dynamic plugins, optionally specifying additional export-dynamic command line arguments.
+    description:
+      Absolute path of the file that contains a yaml dictionary of plugin relative paths to export as dynamic plugins,
+      optionally specifying additional export-dynamic command line arguments.
     required: true
 
   destination:
@@ -19,12 +21,15 @@ inputs:
     default: ^1.8.5
 
   app-config-file-name:
-    description: File name of the app-config files in which we expect to have the default configuration of a frontend plugin.
+    description:
+      File name of the app-config files in which we expect to have the default configuration of a frontend plugin.
     required: false
     default: app-config.dynamic.yaml
 
   scalprum-config-file-name:
-    description: File name of the scalprum config JSON files in which we expect to have the optional scalprum configuration of a frontend plugin.
+    description:
+      File name of the scalprum config JSON files in which we expect to have the optional scalprum configuration of a
+      frontend plugin.
     required: false
     default: scalprum-config.json
 
@@ -33,25 +38,31 @@ inputs:
     required: false
     default: overlay
 
+  base-image-tag-name:
+    description: Base image tag name to publish dynamic plugins as container image
+    default: ""
+    required: false
+
 outputs:
   errors:
-    description: 'The generated random number'
-    value: ${{ steps.run-export-dynamic.outputs.ERRORS }}    
+    description: "The generated random number"
+    value: ${{ steps.run-export-dynamic.outputs.ERRORS }}
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Run ExportDynamic
       id: run-export-dynamic
       shell: bash
       working-directory: '${{ inputs.plugins-root }}'
       env:
-        NPM_CONFIG_ignore-scripts: 'true'
-        YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
-        INPUTS_DESTINATION: '${{ inputs.destination }}'
-        INPUTS_JANUS_CLI_VERSION: '${{ inputs.janus-cli-version }}'
-        INPUTS_PLUGINS_FILE: '${{ inputs.plugins-file }}'
-        INPUTS_APP_CONFIG_FILE_NAME: '${{ inputs.app-config-file-name }}'
-        INPUTS_SCALPRUM_CONFIG_FILE_NAME: '${{ inputs.scalprum-config-file-name }}'
-        INPUTS_SOURCE_OVERLAY_FOLDER_NAME: '${{ inputs.source-overlay-folder-name }}'
+        NPM_CONFIG_ignore-scripts: "true"
+        YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+        INPUTS_DESTINATION: "${{ inputs.destination }}"
+        INPUTS_JANUS_CLI_VERSION: "${{ inputs.janus-cli-version }}"
+        INPUTS_PLUGINS_FILE: "${{ inputs.plugins-file }}"
+        INPUTS_APP_CONFIG_FILE_NAME: "${{ inputs.app-config-file-name }}"
+        INPUTS_SCALPRUM_CONFIG_FILE_NAME: "${{ inputs.scalprum-config-file-name }}"
+        INPUTS_SOURCE_OVERLAY_FOLDER_NAME: "${{ inputs.source-overlay-folder-name }}"
+        INPUTS_BASE_IMAGE_TAG_NAME: "${{ inputs.base-image-tag-name }}"
       run: ${{ github.action_path }}/export-dynamic.sh

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -8,73 +8,92 @@ for plugin in $(cat ${INPUTS_PLUGINS_FILE})
 do
     if [[ "$(echo $plugin | sed 's/ *//')" == "" ]]
     then
-    echo "Skip empty line"
-    continue
+        echo "Skip empty line"
+        continue
     fi
     if [[ "$(echo $plugin | sed 's/^#.*//')" == "" ]]
     then
-    echo "Skip commented line"
-    continue
+        echo "Skip commented line"
+        continue
     fi
     pluginPath=$(echo $plugin | sed 's/^\(^[^:]*\): *\(.*\)$/\1/')
     args=$(echo $plugin | sed 's/^\(^[^:]*\): *\(.*\)$/\2/')
-
+    
     pushd $pluginPath > /dev/null
-
+    
     if [[ "$(grep -e '"role" *: *"frontend-plugin' package.json)" != "" ]]
-    then          
-    pluginType=frontend
-    args="$args --no-in-place"
-
-    optionalScalprumConfigFile="$(dirname ${INPUTS_PLUGINS_FILE})/${pluginPath}/${INPUTS_SCALPRUM_CONFIG_FILE_NAME}"
-    if [ -f "${optionalScalprumConfigFile}" ]
     then
-        args="$args --scalprum-config ${optionalScalprumConfigFile}"
-    fi
-
+        pluginType=frontend
+        args="$args --no-in-place"
+        
+        optionalScalprumConfigFile="$(dirname ${INPUTS_PLUGINS_FILE})/${pluginPath}/${INPUTS_SCALPRUM_CONFIG_FILE_NAME}"
+        if [ -f "${optionalScalprumConfigFile}" ]
+        then
+            args="$args --scalprum-config ${optionalScalprumConfigFile}"
+        fi
+        
     else
-    pluginType=backend
-    args="$args --embed-as-dependencies"
+        pluginType=backend
+        args="$args --embed-as-dependencies"
     fi
-
+    
     echo "========== Exporting $pluginType plugin $pluginPath =========="
-
+    
     optionalSourceOverlay="$(dirname ${INPUTS_PLUGINS_FILE})/${pluginPath}/${INPUTS_SOURCE_OVERLAY_FOLDER_NAME}"
     if [ -d "${optionalSourceOverlay}" ]
     then
-    echo "  copying source overlay"
-    cp -Rfv ${optionalSourceOverlay}/* .
+        echo "  copying source overlay"
+        cp -Rfv ${optionalSourceOverlay}/* .
     fi
-
+    
     set +e
     echo "  running the 'export-dynamic-plugin' command with args: $args"
     echo "$args" | xargs npx --yes @janus-idp/cli@${INPUTS_JANUS_CLI_VERSION} package export-dynamic-plugin
     if [ $? -ne 0 ]
     then
-    errors="${errors}\n${pluginPath}"
-    set -e
-    popd > /dev/null
-    continue
+        errors="${errors}\n${pluginPath}"
+        set -e
+        popd > /dev/null
+        continue
     fi
+
+    # package the dynamic plugin in a container image
+    if [ "${INPUTS_BASE_IMAGE_TAG_NAME}" ]
+    then
+        PLUGIN_NAME=$(grep -o  '"name":\s*".*"' package.json  | cut -d' ' -f2-| sed 's/"//g; s/\//-/g; s/@//g')
+        PLUGIN_VERSION=$(grep -o  '"version":\s*".*"' package.json  | cut -d' ' -f2- | sed 's/"//g; s/^://g')
+        PLUGIN_CONTAINER_TAG="${INPUTS_BASE_IMAGE_TAG_NAME}/${PLUGIN_NAME}:${PLUGIN_VERSION}"
+        echo "========== Packaging Container ${PLUGIN_CONTAINER_TAG} =========="
+
+        npx --yes @janus-idp/cli@${INPUTS_JANUS_CLI_VERSION} package package-dynamic-plugins --tag $PLUGIN_CONTAINER_TAG
+        if [ $? -eq 0 ] 
+        then
+            echo "========== Publishing Container ${PLUGIN_CONTAINER_TAG} =========="
+            podman push $PLUGIN_CONTAINER_TAG
+        else
+            echo " Error building container image"
+        fi
+    fi
+
     echo "  running npm pack on the exported './dist-dynamic' sub-folder"
     json=$(npm pack ./dist-dynamic --pack-destination $packDestination --json)
     if [ $? -ne 0 ]
     then
-    errors="${errors}\n${pluginPath}"
-    set -e
-    popd > /dev/null
-    continue
+        errors="${errors}\n${pluginPath}"
+        set -e
+        popd > /dev/null
+        continue
     fi
     set -e
-
+    
     filename=$(echo "$json" | jq -r '.[0].filename')
     integrity=$(echo "$json" | jq -r '.[0].integrity')
     echo "$integrity" > $packDestination/${filename}.integrity
     optionalConfigFile="$(dirname ${INPUTS_PLUGINS_FILE})/${pluginPath}/${INPUTS_APP_CONFIG_FILE_NAME}"
     if [ -f "${optionalConfigFile}" ]
     then
-    echo "  copying default app-config"
-    cp -v "${optionalConfigFile}" "$packDestination/${filename}.${INPUTS_APP_CONFIG_FILE_NAME}"
+        echo "  copying default app-config"
+        cp -v "${optionalConfigFile}" "$packDestination/${filename}.${INPUTS_APP_CONFIG_FILE_NAME}"
     fi
     popd > /dev/null
 done


### PR DESCRIPTION
Allow users to export container images for dynamic plugins packages. The new flag `publish-container` when selected will publish plugins to Github Container Registry. Later these container images can be used in RHDH.

The image name is the plugin name with `@` removed and `/` replaced by `-`. The image tag is the plugin version.

The resulting images will be available in user account on tab `packages`. Example: https://github.com/jesuino?tab=packages