### PR TITLE
Fix image registry and tag settings and parameters

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -118,9 +118,6 @@ jobs:
 
     env:
       NODE_OPTIONS: --max-old-space-size=8192
-      IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix || format('ghcr.io/{0}', github.actor) }}
-      IMAGE_REGISTRY_USER: ${{ secrets.image-registry-user || github.actor }}
-      IMAGE_REGISTRY_PASSWORD: ${{ secrets.image-registry-password || github.token }}
 
     defaults:
       run:
@@ -204,12 +201,15 @@ jobs:
         if: ${{ inputs.publish-container }}
         uses: redhat-actions/podman-login@v1
         with:
-          username: ${{ env.IMAGE_REGISTRY_USER }}
-          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
-          registry: ${{ env.IMAGE_REPOSITORY_PREFIX }}
+          username: ${{ secrets.image-registry-user }}
+          password: ${{ secrets.image-registry-password }}
+          registry: ${{ inputs.image-repository-prefix }}
 
       - name: Set Plugin Image Repository Prefix
         if: ${{ inputs.publish-container }}
+        env:
+          IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix }}
+
         id: set-image-tag-name
         shell: bash
         run: |

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -42,11 +42,17 @@ on:
 
       publish-container:
         description: Publish a container image for the dynamic plugins
-        required: true
+        required: false
+        default: false
         type: boolean
 
       image-repository-prefix:
         description: Repository prefix of the dynamic plugin container images
+        type: string
+        required: false
+  
+      image-tag-prefix:
+        description: Optional prefix to prepend to the plugin version in the image tag
         type: string
         required: false
   
@@ -190,8 +196,12 @@ jobs:
       upload-project-on-error: ${{ inputs.upload-project-on-error }}
       publish-container: ${{ inputs.publish-container }}
       image-repository-prefix: ${{ inputs.image-repository-prefix }}
-      image-tag-prefix: "bs_${{ needs.prepare.outputs.backstage-version }}__"
+      image-tag-prefix: ${{ inputs.image-tag-prefix != '' && inputs.image-tag-prefix || format('bs_{0}__', needs.prepare.outputs.backstage-version) }}
       last-publish-commit: ${{ inputs.last-publish-commit }}
+
+    secrets:
+      image-registry-password: ${{ secrets.image-registry-password }}
+      image-registry-user: ${{ secrets.image-registry-user }}
 
     permissions:
       contents: write


### PR DESCRIPTION
Implement some fixes related to image registry management and image tag prefix, so that:
- we can set the image tag prefix with more flexibility from the overlay repository workflow (in order to add a specific tag prefix for PR-related published images)
- we forward the image registry username and password from one reusable workflow to the sub-workflow.