### PR TITLE
Don't add workspaces by default, detect missing packages and allow updating an existing PR.

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -23,7 +23,16 @@ on:
         type: boolean
         required: false
         default: false
-  
+ 
+      allow-workspace-addition:
+        type: boolean
+
+      pr-to-update:
+        type: string
+        required: false
+        default: ""
+
+        
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -67,23 +76,20 @@ jobs:
           set -o pipefail
           npm install semver -g
           regexps="${INPUT_REGEXPS}"
-          url="https://api.github.com/repos/${INPUT_OVERLAY_REPO}/branches"
-          result=$(curl -fs ${url})
+          overlayRepoBranchesString=$(gh api repos/${INPUT_OVERLAY_REPO}/branches --jq ".[].name | select(test(\"^$INPUT_RELEASE_BRANCH_PATTERN\"))")
           if [ $? -ne 0 ]
           then
-            echo "Failed fetching '${url}'" >&2
+            echo "Failed fetching branches" >&2
             exit 1
           fi
-          overlayRepoBranchesString=$(echo "$result" | jq -r --arg regex "$INPUT_RELEASE_BRANCH_PATTERN" '.[].name | select(test($regex))')
           supportedBackstageVersions=()
           overlayRepoBranches=()
           for overlayRepoBranch in ${overlayRepoBranchesString}
           do
-            url="https://raw.githubusercontent.com/${INPUT_OVERLAY_REPO}/${overlayRepoBranch}/versions.json"
-            supportedBackstageVersion=$(curl -fs ${url} | jq -r '.backstage')
+            supportedBackstageVersion=$(gh api --header 'Accept: application/vnd.github.v3.raw' "repos/${INPUT_OVERLAY_REPO}/contents/versions.json?ref=${overlayRepoBranch}" --jq .backstage)
             if [ $? -ne 0 ]
             then
-              echo "Failed fetching '${url}'" >&2
+              echo "Failed fetching supported backstage version" >&2
               exit 1
             fi
             supportedBackstageVersions+=("${supportedBackstageVersion}")
@@ -96,27 +102,30 @@ jobs:
             echo '['
             for regexp in ${regexps}
             do
-              if [[ "${regexp}" == *$ ]]
+              if [[ "${regexp}" == \'*\' ]]
               then
-                npmPackages="$(echo ${regexp} | sed 's/.$//')"
+                echo "Using raw plugin name: ${regexp}" >&2
+                npmPackages="$(echo ${regexp} | sed -e 's/^.//' -e 's/.$//')"
               else
                 echo "Searching plugins for regexp: ${regexp}" >&2
                 npmPackages=`npm search "/^(${regexp})/" --searchlimit=1000 --json --no-description --searchexclude "/^(?!(${regexp}))/" | jq -r '.[].name' | sort`
               fi
-              for packageName in ${npmPackages}
-              do
+              missingPackages=''
+              processPackage() {
+                local packageName=$1
+                local searchForMissingPackages=$2
                 if [[ "${packageName}" == *"-node" ]] || [[ "${packageName}" == *"-common" ]] || [[ "${packageName}" == *"-react" ]] 
                 then
                   verbose "  Skipping published package ${packageName}: not a plugin" >&2
-                  continue
+                  return
                 fi
                 npmPackage=$(npm view --json ${packageName} name backstage versions)
                 if [[ "$(echo ${npmPackage} | jq -r '.backstage.role')" != *"-plugin"* ]]
                 then
                   verbose "  Skipping published package ${packageName}: not a plugin" >&2
-                  continue
+                  return
                 fi
-                oneVersionFound=false
+                firstVersionAnalyzed=false
                 echo "  Fetching published versions of plugin ${packageName}" >&2
                 for version in $(echo ${npmPackage} | jq -r '.versions | if type == "string" then . else .[] end | select(test("[^-]+-.+")|not)' | sort -Vr)
                 do
@@ -153,9 +162,11 @@ jobs:
                     then (. | sub("workspaces/(?<name>[^/]*)/plugins/.*"; "\(.name)"))
                     else ""
                     end')
-                  backstageJsonPath="workspaces/${workspace}/backstage.json"
+                  workspacePath="workspaces/${workspace}/"
+                  backstageJsonPath="${workspacePath}backstage.json"
                   if [[ "${workspace}" == "" ]]
                   then
+                    workspacePath="/"
                     workspace=$(echo ${gitRepo} | sed 's:.*/\([^/]*\)$:\1:')
                     backstageJsonPath="backstage.json"
                     if [[ "${gitRepo}" == "backstage/backstage" ]]
@@ -170,12 +181,35 @@ jobs:
                     echo "    Skipping published plugin ${packageName}@${version}: gitHead is not set on the NPM package" >&2
                     continue
                   fi
+                  
+                  if [[ "${searchForMissingPackages}" == "true" && ${firstVersionAnalyzed} == "false" ]]
+                  then
+                    pluginFolders=$(gh api "repos/${gitRepo}/contents/${workspacePath}plugins?ref=${gitHead}" --jq '.[] | select(.type == "dir") | .path + "/package.json"')
+                    if [ $? -ne 0 ]
+                    then
+                      echo "    Failed fetching : '${url}'" >&2
+                      exit 1
+                    fi
+                    while IFS= read -r pluginFolder
+                    do
+                      missingPackageName=$(gh api --header 'Accept: application/vnd.github.v3.raw' "repos/${gitRepo}/contents/${pluginFolder}?ref=${gitHead}" --jq .name)
+                      if [ $? -ne 0 ]
+                      then
+                        echo "    Failed fetching : '${url}'" >&2
+                        exit 1
+                      fi
+                      if ! echo -e "${npmPackages}\n${missingPackages}" | grep "^${missingPackageName}$" &> /dev/null
+                      then
+                        echo "    Adding a missed package: ${missingPackageName} in workspace ${workspace}" >&2
+                        missingPackages="${missingPackages}"$'\n'"${missingPackageName}"
+                      fi
+                    done <<< "${pluginFolders}"
+                  fi
+                  firstVersionAnalyzed=true
 
-                  url="https://raw.githubusercontent.com/${gitRepo}/${gitHead}/${backstageJsonPath}"
-                  backstageVersion=$(curl -fs ${url} | jq -r '.version')
+                  backstageVersion=$(gh api --header 'Accept: application/vnd.github.v3.raw' "repos/${gitRepo}/contents/${backstageJsonPath}?ref=${gitHead}" --jq .version)
                   if [ $? -ne 0 ]
                   then
-                    echo "    Failed fetching : '${url}'" >&2
                     echo "    Skipping published plugin ${packageName}@${version}: Cannot check backstage version " >&2
                     continue
                   fi
@@ -205,12 +239,29 @@ jobs:
                   fi
 
                   echo "    Plugin ${packageName}@${version} selected for export for backstage ${backstageVersion}" >&2
-                  oneVersionFound=true
                   addedFields="{\"workspace\":\"$workspace\", \"backstageVersion\": \"$backstageVersion\", \"branch\": \"$pluginBranch\", \"repo\": \"$gitRepo\", \"flat\": $flat}"
                   pluginInfo=$(echo "${pluginInfo}" | jq ".+= $addedFields")
                   echo -n "${comma} ${pluginInfo}"
                   comma=','
                 done
+              }
+
+              for packageName in ${npmPackages}
+              do
+                if [[ "${packageName}" == "" ]]
+                then
+                  continue
+                fi
+                processPackage ${packageName} 'true'
+              done
+              echo "Processing missed packages" >&2
+              for packageName in ${missingPackages}
+              do
+                if [[ "${packageName}" == "" ]]
+                then
+                  continue
+                fi
+                processPackage ${packageName}, 'false'
               done
             done
             echo ']'
@@ -387,6 +438,8 @@ jobs:
           plugins-repo: ${{ steps.prepare.outputs.plugins-repo }}
           plugins-repo-flat: ${{ steps.prepare.outputs.plugins-repo-flat }}
           plugin-directories: ${{ steps.prepare.outputs.plugin-directories }}
+          allow-workspace-addition: ${{ inputs.allow-workspace-addition }}
+          pr-to-update: ${{ inputs.pr-to-update }}
     
     permissions:
       contents: write

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -261,7 +261,7 @@ jobs:
                 then
                   continue
                 fi
-                processPackage ${packageName}, 'false'
+                processPackage ${packageName} 'false'
               done
             done
             echo ']'

--- a/update-overlay/action.yaml
+++ b/update-overlay/action.yaml
@@ -1,5 +1,5 @@
-name: Update dynamic plugin overlays
-description: Updates an overlay repository structure for a workspace through a PR
+name: Update overlay for workspace
+description: Proposes the addition or update of the overlay repository structure for a workspace through a PR 
 inputs:
   overlay-repo:
     description: ""
@@ -37,6 +37,15 @@ inputs:
     description: ""
     required: true
 
+  allow-workspace-addition:
+    description: ""    
+    required: true
+
+  pr-to-update:
+    description: ""    
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -53,25 +62,11 @@ runs:
         INPUT_WORKSPACE_COMMIT: ${{ inputs.workspace-commit }}
         INPUT_PLUGINS_REPO_FLAT: ${{ inputs.plugins-repo-flat }}
         INPUT_PLUGIN_DIRECTORIES: ${{ inputs.plugin-directories }}
+        INPUT_ALLOW_WORKSPACE_ADDITION: ${{ inputs.allow-workspace-addition }}
+        PR_TO_UPDATE: ${{ inputs.pr-to-update }}
 
       with:
         retries: 4
         script: |
-          const [overlayRepoOwner, overlayRepoName] = core.getInput('overlay_repo').split('/');
-          const [pluginsRepoOwner, pluginsRepoName] = core.getInput('plugins_repo').split('/');
           const script = require('${{ github.action_path }}/create-pr-if-necessary.js');
-          await script({
-            github,
-            core,
-            overlayRepoOwner,
-            overlayRepoName,
-            overlayRepoBranchName: core.getInput('overlay_repo_branch_name'),
-            targetPRBranchName: core.getInput('target_pr_branch_name'),
-            backstageVersion: core.getInput('backstage_version'),
-            workspaceName: core.getInput('workspace_name'),
-            workspaceCommit: core.getInput('workspace_commit'),
-            pluginsRepoOwner,
-            pluginsRepoName,
-            pluginsRepoFlat: core.getInput('plugins_repo_flat'),
-            pluginDirectories: core.getInput('plugin_directories')
-          });
+          await script({github, context, core});

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -1,18 +1,20 @@
-module.exports = async ({
-  github,
-  core,
-  overlayRepoOwner,
-  overlayRepoName,
-  overlayRepoBranchName,
-  targetPRBranchName,
-  backstageVersion,
-  workspaceName,
-  workspaceCommit,
-  pluginsRepoOwner,
-  pluginsRepoName,
-  pluginsRepoFlat,
-  pluginDirectories
-}) => {
+// @ts-check
+/** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
+module.exports = async ({github, context, core}) => {
+  const [overlayRepoOwner, overlayRepoName] = core.getInput('overlay_repo').split('/');
+  const [pluginsRepoOwner, pluginsRepoName] = core.getInput('plugins_repo').split('/');
+  const overlayRepoBranchName = core.getInput('overlay_repo_branch_name');
+  const targetPRBranchName = core.getInput('target_pr_branch_name');
+  const backstageVersion = core.getInput('backstage_version');
+  const workspaceName = core.getInput('workspace_name');
+  const workspaceCommit = core.getInput('workspace_commit');
+  const pluginsRepoFlat = core.getInput('plugins_repo_flat');
+  const pluginDirectories = core.getInput('plugin_directories');
+  const allowWorkspaceAddition = core.getInput('allow_workspace_addition');
+  const prToUpdate = core.getInput('pr_to_update');
+
+  const updateCommitLabel = 'needs-commit-update';
+
   try {
     const githubClient = github.rest;
     
@@ -26,6 +28,7 @@ module.exports = async ({
       repo: pluginsRepoUrl,
       "repo-ref": workspaceCommit,
       "repo-flat": pluginsRepoFlat === 'true',
+      "repo-backstage-version": backstageVersion,
     });
 
     const workspaceLink = pluginsRepoFlat === 'true' ?
@@ -33,43 +36,52 @@ module.exports = async ({
       : `/${pluginsRepoOwner}/${pluginsRepoName}/tree/${workspaceCommit}/workspaces/${workspaceName}`;
 
     core.info(`Checking existing content on the target branch`);
-    let needsUpdate = false;
-    try {
-      const checkExistingResponse = await githubClient.repos.getContent({
-        owner: overlayRepoOwner,
-        repo: overlayRepoName,
-        mediaType: {
-          format: 'text'        
-        }, 
-        path: `${workspacePath}/source.json`,
-        ref: overlayRepoBranchName,
-      })
 
-      if (checkExistingResponse.status === 200) {
-        const data = checkExistingResponse.data;
-        if ('content' in data && data.content !== undefined) {
-          const content = Buffer.from(data.content, 'base64').toString();
-          const sourceInfo = JSON.parse(content); 
-          if (sourceInfo['repo-ref'] === workspaceCommit.trim() &&
-              sourceInfo['repo'] === pluginsRepoUrl &&
-              sourceInfo['repo-flat'] === (pluginsRepoFlat === 'true')
-            ) {
-            core.notice(
-              `Workspace ${workspaceName} already exists on branch ${overlayRepoBranchName} with the same commit ${workspaceCommit.substring(0,7)}`,
-              { title: 'Workspace skipped' }
-            )
-            return;
+    /** @returns { Promise<{ status: 'sourceEqual' | 'sourceNeedsUpdate' | 'workspaceNotFound', repoRef?: string, repo?: string}> } */
+    /** @param {string} branchName */
+    async function checkWorkspace(branchName) {
+      try {
+        const checkExistingResponse = await githubClient.repos.getContent({
+          owner: overlayRepoOwner,
+          repo: overlayRepoName,
+          mediaType: {
+            format: 'text'        
+          },
+          path: `${workspacePath}/source.json`,
+          ref: branchName,
+        })
+
+        if (checkExistingResponse.status === 200) {
+          const data = checkExistingResponse.data;
+          if ('content' in data && data.content !== undefined) {
+            const content = Buffer.from(data.content, 'base64').toString();
+            const sourceInfo = JSON.parse(content); 
+            if (sourceInfo['repo-ref'] === workspaceCommit.trim() &&
+                sourceInfo['repo'] === pluginsRepoUrl &&
+                sourceInfo['repo-flat'] === (pluginsRepoFlat === 'true')
+              ) {
+              return { status: 'sourceEqual' };
+            }
+            return { status: 'sourceNeedsUpdate', repoRef: sourceInfo['repo-ref'], repo: sourceInfo['repo'] };
           }
         }
-        core.info('workspace already exists on the target branch, but needs to be updated');
-        needsUpdate = true;
+        throw new Error(`Unexpected result when checking existing content on branch ${branchName}`);
+      } catch(e) {
+        if (e instanceof Object && 'status' in e && e.status === 404) {
+          return { status: 'workspaceNotFound' };
+        } else {
+          throw e;
+        }
       }
-    } catch(e) {
-      if (e instanceof Object && 'status' in e && e.status === 404) {
-        core.info(`workspace ${workspaceName} not found on branch ${overlayRepoBranchName}`)
-      } else {
-        throw e;
-      }
+    }
+
+    const workspaceCheck = await checkWorkspace(overlayRepoBranchName);
+    if (workspaceCheck.status === 'sourceEqual') {
+      core.notice(
+        `Workspace ${workspaceName} already exists on branch ${overlayRepoBranchName} with the same commit ${workspaceCommit.substring(0,7)}`,
+        { title: 'Workspace skipped' }
+      );
+      return;
     }
 
     core.info(`Checking pull request existence`);
@@ -79,12 +91,111 @@ module.exports = async ({
       base: overlayRepoBranchName,
       head: `${overlayRepoOwner}:${targetPRBranchName}`
     })
+    
+    const existingPR = existingPRs.status === 200 && existingPRs.data.length === 1 ?
+     existingPRs.data[0] :
+     undefined;
 
-    if (existingPRs.status === 200 && existingPRs.data.length === 1) {
-      core.notice(
-        `Pull request for workspace ${workspaceName} based on branch ${targetPRBranchName} already exists; do not try to create it again.`,
-        { title: 'Workspace skipped' }
-      )
+    if (workspaceCheck.status === 'sourceNeedsUpdate') {
+        core.info('workspace already exists on the target branch, but needs to be updated');
+    }
+
+    if (workspaceCheck.status === 'workspaceNotFound' && existingPR === undefined) {
+      core.info(`workspace ${workspaceName} not found on branch ${overlayRepoBranchName}`)
+      if (allowWorkspaceAddition !== 'true') {
+          core.notice(
+            `Workspace ${workspaceName} doesn't already exists on branch ${overlayRepoBranchName}, but workspaces are not automatically added on this branch.`,
+            { title: 'Workspace skipped' }
+          )
+          return;
+      }
+    }
+
+    /** @type { string | undefined } */
+    let commitCompareURL;
+    if (workspaceCheck.status === 'sourceNeedsUpdate' &&
+      workspaceCheck.repo === pluginsRepoUrl
+    ) {
+      const { data: comparison } = await github.rest.repos.compareCommits({
+        owner: pluginsRepoOwner,
+        repo: pluginsRepoName,
+        base: workspaceCheck.repoRef,
+        head: workspaceCommit,
+      });
+      if (comparison.status !== 'ahead') {
+        core.setFailed(
+          `New discovered commit ${workspaceCommit} is not ahead of the previous commit. There is an error in the discovery process.`,
+        );
+        return;
+      }
+      commitCompareURL = comparison.html_url;
+    }
+
+    if (existingPR !== undefined) {
+      const prContentCheck = await checkWorkspace(targetPRBranchName);
+      switch (prContentCheck.status) {
+        case 'sourceEqual':
+          core.notice(
+            `Pull request #${existingPR.number} for workspace ${workspaceName} based on branch ${targetPRBranchName} already exists with the same commit ${workspaceCommit.substring(0,7)}`,
+            { title: 'Workspace skipped' }
+          );
+          return;
+
+        case 'sourceNeedsUpdate':
+          if (prToUpdate === '') {
+            core.notice(
+              `Pull request for workspace ${workspaceName} based on branch ${targetPRBranchName} already exists; do not try to create it again.
+Workspace reference should be manually set to commit ${workspaceCommit}.`,
+              { title: 'Workspace skipped' }
+            )
+
+            let labelAlreadyExists = false;
+            try {
+              const { data: existingLabels} = await githubClient.issues.listLabelsOnIssue({
+                owner: overlayRepoOwner,
+                repo: overlayRepoName,
+                issue_number: existingPR.number,
+                name: updateCommitLabel,
+              })
+              labelAlreadyExists = existingLabels.some(l => l.name === updateCommitLabel);
+            } catch(e) {
+              if (! (e instanceof Object && 'status' in e && e.status === 404)) {
+                throw e;
+              }
+            }
+
+            if (!labelAlreadyExists) {
+              await githubClient.issues.addLabels({
+                owner: overlayRepoOwner,
+                repo: overlayRepoName,
+                issue_number: existingPR.number,
+                labels: [updateCommitLabel],
+              });
+              await github.rest.issues.createComment({
+                owner: overlayRepoOwner,
+                repo: overlayRepoName,
+                issue_number: existingPR.number,
+                body: `A new workspace commit has been discovered.
+You can update this PR with the latest discovered workspace souce commit.
+
+To do so, you can use the \`/update-commit\` instruction in a PR review comment.`,
+              });              
+            }
+            return;
+          }
+          break;
+
+        case 'workspaceNotFound':
+          core.warning(`workspace ${workspaceName} not found on branch ${targetPRBranchName}, but should be there`)
+          break;
+      }
+    }
+
+    if (prToUpdate !== '' && prToUpdate !== existingPR?.number.toString()) {
+      core.setFailed(
+        `Pull request ${prToUpdate} cannot be updated, because no automatically-created PR based on branch ${targetPRBranchName} was found.
+Workspace reference should be manually set to commit ${workspaceCommit}.`,
+      );
       return;
     }
 
@@ -98,7 +209,7 @@ module.exports = async ({
       })
 
       if (prCheckResponse.status === 200) {
-        core.info('pull request branch already exists, but the corresponding PR is missing. Only the PR will be created.')
+        core.info('pull request branch already exists, but the corresponding PR is missing. The PR will be created.');
         prBranchExists = true;
       }
     } catch(e) {
@@ -109,15 +220,15 @@ module.exports = async ({
       }
     }
 
-    const needsUpdateMessage = needsUpdate ? 'Update' : 'Add';
+    const needsUpdateMessage = workspaceCheck.status === 'sourceNeedsUpdate' ? 'Update' : 'Add';
     const message = `${needsUpdateMessage} \`${workspaceName}\` workspace to commit \`${workspaceCommit.substring(0,7)}\` for backstage \`${backstageVersion}\` on branch \`${overlayRepoBranchName}\``
 
-    if (! prBranchExists) {
+    if (! prBranchExists || prToUpdate !== '') {
       core.info(`Getting latest commit sha and treeSha of the target branch`);
       const response = await githubClient.repos.listCommits({
         owner: overlayRepoOwner,
         repo: overlayRepoName,
-        sha: overlayRepoBranchName,
+        sha: prToUpdate === '' ? overlayRepoBranchName : targetPRBranchName,
         per_page: 1,
       })
 
@@ -125,7 +236,7 @@ module.exports = async ({
       const treeSha = response.data[0].commit.tree.sha;
       
       core.info(`Creating tree`);
-      core.debug(`treeSha: ${treeSha}`);
+      core.debug(`on treeSha: ${treeSha}`);
       
       const treeResponse = await githubClient.git.createTree({
         owner: overlayRepoOwner,
@@ -147,54 +258,98 @@ module.exports = async ({
         parents: [latestCommitSha],
       })
       const newCommitSha = commitResponse.data.sha
+      core.debug(`new commit sha: ${newCommitSha}`);
 
-      core.info(`Creating branch`);
-      await githubClient.git.createRef({
-        owner: overlayRepoOwner,
-        repo: overlayRepoName,
-        sha: newCommitSha,
-        ref: `refs/heads/${targetPRBranchName}`
-      })
+      if (prToUpdate === '') {
+        core.info(`Creating branch`);
+        await githubClient.git.createRef({
+          owner: overlayRepoOwner,
+          repo: overlayRepoName,
+          sha: newCommitSha,
+          ref: `refs/heads/${targetPRBranchName}`
+        })
+      } else {
+        core.info(`Updating branch`);
+        await githubClient.git.updateRef({
+          owner: overlayRepoOwner,
+          repo: overlayRepoName,
+          sha: newCommitSha,
+          ref: `heads/${targetPRBranchName}`
+        })
+      }
     }
-    
-    core.info(`Creating pull request`);
-    const prResponse = await githubClient.pulls.create({
-      owner: overlayRepoOwner,
-      repo: overlayRepoName,
-      head: targetPRBranchName,
-      base: overlayRepoBranchName,
-      title: message,
-      body: `${needsUpdateMessage} [${workspaceName}](${workspaceLink}) workspace at commit ${pluginsRepoOwner}/${pluginsRepoName}@${workspaceCommit} for backstage \`${backstageVersion}\` on branch \`${overlayRepoBranchName}\`.
+        
+    let body = `${needsUpdateMessage} [${workspaceName}](${workspaceLink}) workspace at commit ${pluginsRepoOwner}/${pluginsRepoName}@${workspaceCommit} for backstage \`${backstageVersion}\` on branch \`${overlayRepoBranchName}\`.
 
-This PR was created automatically.
+This PR was created automatically.`;
+    if (workspaceCheck.status !== 'sourceNeedsUpdate') {
+      body = `${body}
 You might need to complete it with additional dynamic plugin export information, like:
 - the associated \`app-config.dynamic.yaml\` file for frontend plugins,
 - optionally the \`scalprum-config.json\` file for frontend plugins,
-- optionally some overlay source files for backend or frontend plugins.
+- optionally some overlay source files at the plugin level,
+- optionally a \`patch\` file at the workspace level`;
+    } else if (commitCompareURL !== undefined) {
+      body = `${body}
+Click on the following link to see the source diff it introduces: ${commitCompareURL}.`;
+    }
+    body = `${body}
 
 Before merging, you need to export the workspace dynamic plugins as OCI images,
-and test them inside a RHDH instance.
+and if possible test them inside a RHDH instance.
 
 To do so, you can use the \`/publish\` instruction in a PR review comment.
 This will start a PR check workflow to:
 - export the workspace plugins as dynamic plugins,
 - publish them as OCI images
 - push the oci-images in the GitHub container registry with a PR-specific tag.
-`,
-    });
+`;
+
+    let prResponse;
+    if (prToUpdate === '') {
+      core.info(`Creating pull request`);
+      prResponse = await githubClient.pulls.create({
+        owner: overlayRepoOwner,
+        repo: overlayRepoName,
+        head: targetPRBranchName,
+        base: overlayRepoBranchName,
+        title: message,
+        body,
+      });
+    } else {
+      core.info(`Updating pull request`);
+      prResponse = await githubClient.pulls.update({
+        owner: overlayRepoOwner,
+        repo: overlayRepoName,
+        pull_number: Number.parseInt(prToUpdate),
+        head: targetPRBranchName,
+        base: overlayRepoBranchName,
+        title: message,
+        body,
+      });
+      try {
+        await githubClient.issues.removeLabel({
+          owner: overlayRepoOwner,
+          repo: overlayRepoName,
+          issue_number: Number.parseInt(prToUpdate),
+          name: updateCommitLabel,
+        });
+      } catch(e) {}
+    }
 
     core.info(`Adding summary with workspace link`);
 
+    const done = prToUpdate === '' ? 'created' : 'updated';
     await core.summary
-    .addHeading('Workspace PR created')
+    .addHeading(`Workspace PR ${done}`)
     .addLink('Pull request', prResponse.data.html_url)
     .addRaw(` on branch ${overlayRepoBranchName}`)
-    .addRaw(' created for workspace ')
+    .addRaw(` ${done} for workspace `)
     .addLink(workspaceName, workspaceLink)
     .addRaw(` at commit ${workspaceCommit.substring(0,7)} for backstage ${backstageVersion}`)
     .write();
   } catch (error) {
     // Fail the workflow run if an error occurs
-    if (error instanceof Error) core.setFailed(error.stack);
+    if (error instanceof Error) core.setFailed(error.stack ?? error);
   }
 }


### PR DESCRIPTION
This PR fixes a number of limitations of the existing UpdatePluginRepoRefs workflow, to prepare for future process enhancements of the overlay repository:
- it adds on option to allow adding new discovered workspaces as PRs. So now by default PR should only be created for updates to the `source.json` file of existing workspaces should be created as PRs,
- allows modifying an existing PR to update the source.json file with a new commit (with a dedicated argument),
- detects and adds packages that would be missing in the result returned by the `npm search` call based on regular expressions,
- label PRs whose source.json should be updated with a more recent commit.