### PR TITLE
feat(export-dynamic): allow for a patch directory

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -188,14 +188,6 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
-        
-      - name: Run yarn install
-        run: |
-          yarn --version
-          yarn install --immutable
-
-      - name: Run Typescript type checking
-        run: yarn tsc
 
       - name: Log in to container registry
         if: ${{ inputs.publish-container }}

--- a/export-dynamic/apply-patches.sh
+++ b/export-dynamic/apply-patches.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Absolute path to the .../overlay-root/patches directory
+PATCHES_SOURCE_DIR="$1" 
+
+# Expected to be "." if CWD is already the target, or an absolute path to cd into
+TARGET_APPLY_DIR_ARG="$2"
+
+echo "=== Apply Patches Script ==="
+echo "  Source of patches: ${PATCHES_SOURCE_DIR}"
+
+EFFECTIVE_TARGET_APPLY_DIR=$(pwd)
+PUSHED_DIR=false # Flag to track if we actually changed directory
+
+# Cleanup function to ensure we pop back if a directory was pushed
+_cleanup() {
+  if [ "$PUSHED_DIR" = true ]
+  then
+    popd > /dev/null
+  fi
+}
+trap _cleanup EXIT 
+
+if [[ "${TARGET_APPLY_DIR_ARG}" != "." ]]
+then
+  if [ ! -d "$TARGET_APPLY_DIR_ARG" ]
+  then
+    echo "Error: Specified target directory for applying patches ($TARGET_APPLY_DIR_ARG) does not exist."
+    exit 1
+  fi
+  pushd "$TARGET_APPLY_DIR_ARG" > /dev/null
+  PUSHED_DIR=true
+  echo "  Changed working directory to: $(pwd) for applying patches"
+else
+  echo "  Applying patches in current working directory: $(pwd)"
+fi
+
+if [[ ! -d "$PATCHES_SOURCE_DIR" ]]
+then
+  echo "Patches directory ($PATCHES_SOURCE_DIR) not found. Skipping patching."
+  exit 0
+fi
+
+# Find and sort .patch files to ensure ordered application
+readarray -t PATCH_FILES < <(find "$PATCHES_SOURCE_DIR" -maxdepth 1 -type f -name "*.patch" | sort)
+
+if [ ${#PATCH_FILES[@]} -eq 0 ]
+then
+  echo "No .patch files found in $PATCHES_SOURCE_DIR. Skipping patching."
+  exit 0
+fi
+
+echo "Found patch files to apply in $(pwd):"
+printf "  - %s\n" "${PATCH_FILES[@]}"
+
+for patch_file in "${PATCH_FILES[@]}"; do
+  echo "Attempting to apply patch: $patch_file"
+  if git apply --check "$patch_file"; then
+    git apply "$patch_file"
+    echo "Successfully applied patch: $patch_file"
+  else
+    echo "Error: Patch $patch_file could not be applied cleanly in $(pwd)." >&2
+    exit 1 # Fail if a patch cannot be applied
+  fi
+done
+
+echo "All patches applied successfully in $(pwd)."
+echo "=== Apply Patches Script Finished ==="
+exit 0

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -7,6 +7,8 @@ IFS=$'\n'
 workspaceOverlayFolder="$(dirname ${INPUTS_PLUGINS_FILE})"
 skipWorkspace=false
 
+exportDynamicScriptPath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 set -e
 if [[ "${INPUTS_LAST_PUBLISH_COMMIT}" != "" ]]
 then
@@ -24,12 +26,25 @@ if [[ "${skipWorkspace}" == "true" ]]
 then
     echo "Skipping workspace since it didn't change since last published commit (${INPUTS_LAST_PUBLISH_COMMIT})"
 else
-    optionalPatch="${workspaceOverlayFolder}/${INPUTS_SOURCE_PATCH_FILE_NAME}"
-    if [ -f "${optionalPatch}" ]
+    echo "========== Processing workspace ${workspaceOverlayFolder} =========="
+
+    applyPatchesScriptPath="${exportDynamicScriptPath}/apply-patches.sh"
+    patchesDirAbsolute="${workspaceOverlayFolder}/patches"
+
+    echo "  Attempting to apply patches from: ${patchesDirAbsolute}"
+    if ! "${applyPatchesScriptPath}" "${patchesDirAbsolute}" "." 
     then
-        echo "  applying patch on plugin sources"
-        patch <${optionalPatch}
+      echo "Error: Patching failed. Exiting." >&2
+      exit 1
     fi
+    echo "  Patching completed successfully."
+
+    echo "  Running 'yarn install' in $(pwd)..."
+    yarn install
+
+    echo "  Running 'yarn tsc' in $(pwd)..."
+    yarn tsc
+    echo "  TypeScript type checking completed."
 
     for plugin in $(cat ${INPUTS_PLUGINS_FILE})
     do


### PR DESCRIPTION
This change updates the export-dynamic workflow and script to allow for a workspace to supply a directory containing patch files alongside the `plugins.yaml` file which will be applied in sequence based on the filename.  The export-dynamic workflow no longer performs the `yarn install` and `yarn tsc` as this will be done in the `export-dynamic.sh` script.  Because it's possible to patch `package.json` files the `--immutable` flag is not used when running `yarn install` after the patches have been applied.


Assisted-by: Gemini Code Assist