### PR TITLE
add cli-package option

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -19,7 +19,11 @@ on:
         description: Version of the janus-idp/cli package.
         type: string
         required: true        
-
+      cli-package:
+        description: Package name of the cli package.
+        type: string
+        required: false
+        default: "@janus-idp/cli"
       plugins-repo:
         description:
           Name of the repository that contains the backstage plugins to be exported as dynamic. For example
@@ -271,6 +275,7 @@ jobs:
           plugins-file: ${{ github.workspace }}/overlay-repo/${{inputs.overlay-root}}/plugins-list.yaml
           destination: ${{ github.workspace }}/dynamic-plugin-archives
           janus-cli-version: ${{inputs.janus-cli-version}}
+          cli-package: ${{inputs.cli-package}}
           image-repository-prefix: ${{ steps.set-image-tag-name.outputs.IMAGE_REPOSITORY_PREFIX }}
           image-tag-prefix: ${{ inputs.image-tag-prefix }}
           last-publish-commit: ${{ inputs.last-publish-commit }}

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -23,6 +23,12 @@ on:
         required: false
         default: ''
 
+      cli-package:
+        description: Package name of the cli package.
+        type: string
+        required: false
+        default: "@janus-idp/cli"
+
       upload-project-on-error:
         description: Upload the complete project as a workflow artifact in case of error in order to troubleshoot.
         required: false
@@ -82,6 +88,7 @@ jobs:
     outputs:
       node-version: ${{ steps.set-env-vars.outputs.NODE_VERSION }}
       janus-cli-version: ${{ steps.set-env-vars.outputs.JANUS_CLI_VERSION }}
+      cli-package: ${{ steps.set-env-vars.outputs.CLI_PACKAGE }}
       backstage-version: ${{ steps.set-env-vars.outputs.BACKSTAGE_VERSION }}
       workspaces: ${{ steps.gather-workspaces.outputs.workspaces }}
       overlay-repo-ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
@@ -134,6 +141,7 @@ jobs:
         env:
           INPUT_NODE_VERSION: ${{ inputs.node-version }}
           INPUT_JANUS_CLI_VERSION: ${{ inputs.janus-cli-version }}
+          INPUT_CLI_PACKAGE: ${{ inputs.cli-package }}
         run: |
           versions=$(cat versions.json)
 
@@ -142,6 +150,9 @@ jobs:
 
           JANUS_CLI_VERSION=$(echo ${versions} | jq -r "if (\"${INPUT_JANUS_CLI_VERSION}\" == \"\") then (.cli // \"^3.0.0\") else \"${INPUT_JANUS_CLI_VERSION}\" end")
           echo "JANUS_CLI_VERSION=$JANUS_CLI_VERSION" >> $GITHUB_OUTPUT
+
+          CLI_PACKAGE=$(echo ${versions} | jq -r "if (\"${INPUT_CLI_PACKAGE}\" == \"\") then (.cliPackage // \"@janus-idp/cli\") else \"${INPUT_CLI_PACKAGE}\" end")
+          echo "CLI_PACKAGE=$CLI_PACKAGE" >> $GITHUB_OUTPUT
 
           BACKSTAGE_VERSION=$(echo ${versions} | jq -r ".backstage")
           echo "BACKSTAGE_VERSION=$BACKSTAGE_VERSION" >> $GITHUB_OUTPUT
@@ -209,6 +220,7 @@ jobs:
       overlay-root: ${{ matrix.workspace.overlay-root }}
       node-version: ${{ needs.prepare.outputs.node-version }}
       janus-cli-version: ${{ needs.prepare.outputs.janus-cli-version }}
+      cli-package: ${{ needs.prepare.outputs.cli-package }}
       upload-project-on-error: ${{ inputs.upload-project-on-error }}
       publish-container: ${{ inputs.publish-container }}
       image-repository-prefix: ${{ inputs.image-repository-prefix }}

--- a/export-dynamic/action.yaml
+++ b/export-dynamic/action.yaml
@@ -21,6 +21,11 @@ inputs:
     required: false
     default: ^1.8.5
 
+  cli-package:
+    description: Package name of the cli package.
+    required: false
+    default: "@janus-idp/cli"
+
   app-config-file-name:
     description:
       File name of the app-config files in which we expect to have the default configuration of a frontend plugin.
@@ -93,6 +98,7 @@ runs:
         YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
         INPUTS_DESTINATION: "${{ inputs.destination }}"
         INPUTS_JANUS_CLI_VERSION: "${{ inputs.janus-cli-version }}"
+        INPUTS_CLI_PACKAGE: "${{ inputs.cli-package }}"
         INPUTS_PLUGINS_FILE: "${{ inputs.plugins-file }}"
         INPUTS_APP_CONFIG_FILE_NAME: "${{ inputs.app-config-file-name }}"
         INPUTS_SCALPRUM_CONFIG_FILE_NAME: "${{ inputs.scalprum-config-file-name }}"

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -71,7 +71,7 @@ else
 
         set +e
         echo "  running the 'export-dynamic-plugin' command with args: $args"
-        echo "$args" | xargs npx --yes @janus-idp/cli@${INPUTS_JANUS_CLI_VERSION} package export-dynamic-plugin
+        echo "$args" | xargs npx --yes ${INPUTS_CLI_PACKAGE}@${INPUTS_JANUS_CLI_VERSION} package export-dynamic-plugin
         if [ $? -ne 0 ]
         then
             errors+=("${pluginPath}")
@@ -88,7 +88,7 @@ else
             PLUGIN_CONTAINER_TAG="${INPUTS_IMAGE_REPOSITORY_PREFIX}/${PLUGIN_NAME}:${PLUGIN_VERSION}"
 
             echo "========== Packaging Container ${PLUGIN_CONTAINER_TAG} =========="
-            npx --yes @janus-idp/cli@${INPUTS_JANUS_CLI_VERSION} package package-dynamic-plugins --tag "${PLUGIN_CONTAINER_TAG}"
+            npx --yes ${INPUTS_CLI_PACKAGE}@${INPUTS_JANUS_CLI_VERSION} package package-dynamic-plugins --tag "${PLUGIN_CONTAINER_TAG}"
             if [ $? -eq 0 ] 
             then
                 if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]


### PR DESCRIPTION
Adds new optional parameter `cli-package` (`cliPackage` in versions.json) to workflows that allows specifying which cli pakage should be used.

Defaults to `janus-idp/cli` to ensure backwards compatiblity 