### PR TITLE
Added automatic updates for version fields in plugin metadata files

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -592,6 +592,7 @@ jobs:
             core.setOutput('plugins-repo', workspace.repo);
             core.setOutput('plugins-repo-flat', workspace.flat);
             core.setOutput('plugin-directories', workspace.plugins.map((plugin) => plugin.directory).join('\n'));
+            core.setOutput('workspace-json', workspaceJson);
             return {};
 
       - name: Create PR if necessary
@@ -608,6 +609,7 @@ jobs:
           plugins-repo: ${{ steps.prepare.outputs.plugins-repo }}
           plugins-repo-flat: ${{ steps.prepare.outputs.plugins-repo-flat }}
           plugin-directories: ${{ steps.prepare.outputs.plugin-directories }}
+          workspace-json: ${{ steps.prepare.outputs.workspace-json }}
           allow-workspace-addition: ${{ inputs.allow-workspace-addition }}
           pr-to-update: ${{ inputs.pr-to-update }}
     

--- a/update-overlay/action.yaml
+++ b/update-overlay/action.yaml
@@ -50,6 +50,11 @@ inputs:
     required: false
     default: ""
 
+  workspace-json:
+    description: "Full workspace JSON object from the gather step, used for metadata updates and future extensions"
+    required: false
+    default: "{}"
+
 runs:
   using: "composite"
   steps:
@@ -69,6 +74,7 @@ runs:
         INPUT_PLUGIN_DIRECTORIES: ${{ inputs.plugin-directories }}
         INPUT_ALLOW_WORKSPACE_ADDITION: ${{ inputs.allow-workspace-addition }}
         INPUT_PR_TO_UPDATE: ${{ inputs.pr-to-update }}
+        INPUT_WORKSPACE_JSON: ${{ inputs.workspace-json }}
 
       with:
         retries: 4

--- a/update-overlay/action.yaml
+++ b/update-overlay/action.yaml
@@ -58,6 +58,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm install --no-audit --no-fund
     - name: Create PR if necessary
       id: create-pr-if-necessary
       uses: actions/github-script@v7

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -13,6 +13,14 @@ module.exports = async ({github, context, core}) => {
   const pluginDirectories = core.getInput('plugin_directories');
   const allowWorkspaceAddition = core.getInput('allow_workspace_addition');
   const prToUpdate = core.getInput('pr_to_update');
+  const workspaceJson = JSON.parse(core.getInput('workspace_json') || '{}');
+  /** @type {Record<string, string>} */
+  const pluginVersions = {};
+  for (const plugin of workspaceJson.plugins ?? []) {
+    pluginVersions[plugin.name] = plugin.version;
+  }
+
+  /** @typedef {{ name: string, object: { text: string } | null }} MetadataFileEntry */
 
   const updateCommitLabel = 'needs-commit-update';
 
@@ -41,11 +49,11 @@ module.exports = async ({github, context, core}) => {
   
     core.info(`Checking existing content on the target branch`);
 
-    /** @returns { Promise<{ status: 'sourceEqual' | 'sourceNeedsUpdate' | 'workspaceNotFound', repoRef?: string, repo?: string, backstageVersionOverride?: string, pluginsYamlContent?: string }> } */
+    /** @returns { Promise<{ status: 'sourceEqual' | 'sourceNeedsUpdate' | 'workspaceNotFound', repoRef?: string, repo?: string, backstageVersionOverride?: string, pluginsYamlContent?: string, metadataEntries?: MetadataFileEntry[] }> } */
     /** @param {string} branchName */
     async function checkWorkspace(branchName) {
       try {
-        /** @type { { repository: { pluginsList: { text: string } | null, sourceJson: { text: string } | null, backstageJson: { text: string } | null } } } */
+        /** @type { { repository: { pluginsList: { text: string } | null, sourceJson: { text: string } | null, backstageJson: { text: string } | null, metadataTree: { entries: MetadataFileEntry[] } | null } } } */
         const response = await github.graphql(`
           query GetFileContents($owner: String!, $repo: String!) {
             repository(owner: $owner, name: $repo) {
@@ -64,6 +72,18 @@ module.exports = async ({github, context, core}) => {
                   text
                 }
               }
+              metadataTree: object(expression: "${branchName}:${workspacePath}/metadata") {
+                ... on Tree {
+                  entries {
+                    name
+                    object {
+                      ... on Blob {
+                        text
+                      }
+                    }
+                  }
+                }
+              }
             }
           }`, {
           owner: overlayRepoOwner,
@@ -75,9 +95,10 @@ module.exports = async ({github, context, core}) => {
         }
 
         const backstageVersionOverride = response.repository.backstageJson ? JSON.parse(response.repository.backstageJson.text).version : undefined;
+        const metadataEntries = response.repository.metadataTree?.entries ?? [];
 
         if (! response.repository.sourceJson && ! response.repository.pluginsList) {
-          return { status: 'workspaceNotFound', backstageVersionOverride };
+          return { status: 'workspaceNotFound', backstageVersionOverride, metadataEntries };
         }
 
         if (! response.repository.sourceJson) {
@@ -92,7 +113,7 @@ module.exports = async ({github, context, core}) => {
             sourceInfo['repo'] === pluginsRepoUrl &&
             sourceInfo['repo-flat'] === (pluginsRepoFlat === 'true')
           ) {
-          return { status: 'sourceEqual', backstageVersionOverride, pluginsYamlContent: response.repository.pluginsList.text };
+          return { status: 'sourceEqual', backstageVersionOverride, pluginsYamlContent: response.repository.pluginsList.text, metadataEntries };
         }
 
         let pluginsYamlContent = newPluginsYamlContent ;
@@ -124,7 +145,7 @@ module.exports = async ({github, context, core}) => {
           }
         }
 
-        return { status: 'sourceNeedsUpdate', repoRef: sourceInfo['repo-ref'], repo: sourceInfo['repo'], backstageVersionOverride, pluginsYamlContent };
+        return { status: 'sourceNeedsUpdate', repoRef: sourceInfo['repo-ref'], repo: sourceInfo['repo'], backstageVersionOverride, pluginsYamlContent, metadataEntries };
       } catch(e) {
         if ('toString' in e) {
           throw Error(`Failed when checking existing content on branch ${branchName}: ${e.toString()}`);
@@ -132,6 +153,80 @@ module.exports = async ({github, context, core}) => {
           throw e;
         }
       }
+    }
+
+    const packageNameRegex = /^\s+packageName:\s*['"]?([^\s'"]+)['"]?\s*$/m;
+    const versionRegex = /^(\s+version:\s*)\S.*$/m;
+    const artifactRegex = /^(\s+dynamicArtifact:\s*oci:\/\/ghcr\.io\/[^:]+:)[^\s!]+(![^\s!]+)$/m;
+
+    /**
+     * Process a single metadata file, updating version and dynamicArtifact tag
+     * to match the plugin version discovered from NPM.
+     * @param {MetadataFileEntry} entry
+     * @returns {{ path: string, mode: string, content: string } | null}
+     */
+    function processMetadataEntry(entry) {
+      if (!entry.object?.text) return null;
+
+      let content = entry.object.text;
+      const packageNameMatch = packageNameRegex.exec(content);
+      if (!packageNameMatch) return null;
+
+      const newVersion = pluginVersions[packageNameMatch[1]];
+      if (!newVersion) return null;
+
+      let modified = false;
+
+      const versionMatch = versionRegex.exec(content);
+      if (versionMatch && versionMatch[0].trim() !== `version: ${newVersion}`) {
+        content = content.replace(versionRegex, `$1${newVersion}`);
+        core.info(`  Updated version to ${newVersion} in ${entry.name}`);
+        modified = true;
+      }
+
+      if (artifactRegex.exec(content)) {
+        const newTag = `bs_${backstageVersion}__${newVersion}`;
+        content = content.replace(artifactRegex, `$1${newTag}$2`);
+        core.info(`  Updated dynamicArtifact tag in ${entry.name}`);
+        modified = true;
+      }
+
+      if (!modified) return null;
+
+      return {
+        path: `${workspacePath}/metadata/${entry.name}`,
+        mode: '100644',
+        content,
+      };
+    }
+
+    /**
+     * Update spec.version and spec.dynamicArtifact (oci://ghcr.io) in metadata
+     * files to match the plugin versions discovered from NPM.
+     * @param {MetadataFileEntry[]} entries
+     * @returns {Array<{path: string, mode: string, content: string}>}
+     */
+    function updateMetadataFiles(entries) {
+      if (Object.keys(pluginVersions).length === 0 || entries.length === 0) {
+        return [];
+      }
+
+      /** @type {Array<{path: string, mode: string, content: string}>} */
+      const treeEntries = [];
+
+      for (const entry of entries) {
+        if (!entry.name.endsWith('.yaml') && !entry.name.endsWith('.yml')) continue;
+        const result = processMetadataEntry(entry);
+        if (result) {
+          treeEntries.push(result);
+        }
+      }
+
+      if (treeEntries.length > 0) {
+        core.info(`Updated ${treeEntries.length} metadata file(s)`);
+      }
+
+      return treeEntries;
     }
 
     const workspaceCheck = await checkWorkspace(overlayRepoBranchName);
@@ -379,6 +474,9 @@ Workspace reference should be manually set to commit ${workspaceCommit}.`,
       core.info(`Deleting the overridden \`backstage.json\` because it's out-of-sync (\`${workspaceCheck.backstageVersionOverride}\`) with the backstage version of the new source commit (\`${backstageVersion}\`)`);
     }
     
+    const metadataEntries = (prBranchExists ? prContentCheck?.metadataEntries : workspaceCheck.metadataEntries) ?? [];
+    const metadataTreeEntries = updateMetadataFiles(metadataEntries);
+
     /** @type { Parameters<typeof githubClient.git.createTree>[0] } */
     const createTreeOptions = {
       owner: overlayRepoOwner,
@@ -387,6 +485,7 @@ Workspace reference should be manually set to commit ${workspaceCommit}.`,
       tree: [
         { path: `${workspacePath}/plugins-list.yaml`, mode: '100644', content: updatedPluginsYamlContent },
         { path: `${workspacePath}/source.json`, mode: '100644', content: newSourceJsonContent },
+        ...metadataTreeEntries,
       ]
     };
     if (deleteBackstageJson) {

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -1,4 +1,5 @@
 // @ts-check
+const YAML = require('yaml');
 /** @param {import('@actions/github-script').AsyncFunctionArguments} AsyncFunctionArguments */
 module.exports = async ({github, context, core}) => {
   const [overlayRepoOwner, overlayRepoName] = core.getInput('overlay_repo').split('/');
@@ -155,9 +156,7 @@ module.exports = async ({github, context, core}) => {
       }
     }
 
-    const packageNameRegex = /^\s+packageName:\s*['"]?([^\s'"]+)['"]?\s*$/m;
-    const versionRegex = /^(\s+version:\s*)\S.*$/m;
-    const artifactRegex = /^(\s+dynamicArtifact:\s*oci:\/\/ghcr\.io\/[^:]+:)[^\s!]+(![^\s!]+)$/m;
+    const ociGhcrTagPattern = /^(oci:\/\/ghcr\.io\/[^:]+:)[^\s!]+(![^\s!]+)$/;
 
     /**
      * Process a single metadata file, updating version and dynamicArtifact tag
@@ -168,27 +167,31 @@ module.exports = async ({github, context, core}) => {
     function processMetadataEntry(entry) {
       if (!entry.object?.text) return null;
 
-      let content = entry.object.text;
-      const packageNameMatch = packageNameRegex.exec(content);
-      if (!packageNameMatch) return null;
+      const doc = YAML.parseDocument(entry.object.text);
+      const packageName = doc.getIn(['spec', 'packageName']);
+      if (!packageName) return null;
 
-      const newVersion = pluginVersions[packageNameMatch[1]];
+      const newVersion = pluginVersions[packageName];
       if (!newVersion) return null;
 
       let modified = false;
 
-      const versionMatch = versionRegex.exec(content);
-      if (versionMatch && versionMatch[0].trim() !== `version: ${newVersion}`) {
-        content = content.replace(versionRegex, `$1${newVersion}`);
+      const currentVersion = doc.getIn(['spec', 'version']);
+      if (currentVersion != null && String(currentVersion) !== newVersion) {
+        doc.setIn(['spec', 'version'], newVersion);
         core.info(`  Updated version to ${newVersion} in ${entry.name}`);
         modified = true;
       }
 
-      if (artifactRegex.exec(content)) {
-        const newTag = `bs_${backstageVersion}__${newVersion}`;
-        content = content.replace(artifactRegex, `$1${newTag}$2`);
-        core.info(`  Updated dynamicArtifact tag in ${entry.name}`);
-        modified = true;
+      const dynamicArtifact = doc.getIn(['spec', 'dynamicArtifact']);
+      if (typeof dynamicArtifact === 'string') {
+        const ociMatch = dynamicArtifact.match(ociGhcrTagPattern);
+        if (ociMatch) {
+          const newTag = `bs_${backstageVersion}__${newVersion}`;
+          doc.setIn(['spec', 'dynamicArtifact'], `${ociMatch[1]}${newTag}${ociMatch[2]}`);
+          core.info(`  Updated dynamicArtifact tag in ${entry.name}`);
+          modified = true;
+        }
       }
 
       if (!modified) return null;
@@ -196,7 +199,7 @@ module.exports = async ({github, context, core}) => {
       return {
         path: `${workspacePath}/metadata/${entry.name}`,
         mode: '100644',
-        content,
+        content: doc.toString(),
       };
     }
 

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -188,9 +188,12 @@ module.exports = async ({github, context, core}) => {
         const ociMatch = dynamicArtifact.match(ociGhcrTagPattern);
         if (ociMatch) {
           const newTag = `bs_${backstageVersion}__${newVersion}`;
-          doc.setIn(['spec', 'dynamicArtifact'], `${ociMatch[1]}${newTag}${ociMatch[2]}`);
-          core.info(`  Updated dynamicArtifact tag in ${entry.name}`);
-          modified = true;
+          const newDynamicArtifact = `${ociMatch[1]}${newTag}${ociMatch[2]}`;
+          if (newDynamicArtifact !== dynamicArtifact) {
+            doc.setIn(['spec', 'dynamicArtifact'], newDynamicArtifact);
+            core.info(`  Updated dynamicArtifact tag in ${entry.name}`);
+            modified = true;
+          }
         }
       }
 

--- a/update-overlay/package-lock.json
+++ b/update-overlay/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "update-overlay",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "update-overlay",
+      "version": "1.0.0",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/update-overlay/package.json
+++ b/update-overlay/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "update-overlay",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "yaml": "^2.8.0"
+  }
+}


### PR DESCRIPTION
Automated the updating for `spec.version` and `spec.dynamicArtifact` (only for `ghcr.io`). 
It updates the known values and commits back to the branch.
This should reduce the need to do it manually (e.g. when using the update workflow in overlays).
