### PR TITLE
chore: update to allow for split workflow and also not error when provided a image registry with uppercase characters

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -335,12 +335,12 @@ jobs:
         env:
           PUBLISHED_EXPORTS: ${{ steps.export-dynamic.outputs.published-exports }}
         run: |
-          mkdir -p container-images
+          mkdir -p $GITHUB_WORKSPACE/container-images
           while IFS= read -r image; do
             [ -z "$image" ] && continue
             name=$(echo "$image" | sed 's|.*/||; s/:/-/')
-            echo "Saving $image -> container-images/${name}.tar"
-            podman save -o "container-images/${name}.tar" "$image"
+            echo "Saving $image -> $GITHUB_WORKSPACE/container-images/${name}.tar"
+            podman save -o "$GITHUB_WORKSPACE/container-images/${name}.tar" "$image"
           done <<< "$PUBLISHED_EXPORTS"
 
       - name: Upload container image archives
@@ -348,7 +348,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: container-images${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
-          path: container-images/
+          path: ${{ github.workspace }}/container-images/
           if-no-files-found: warn
           retention-days: ${{ inputs.artifact-retention-days }}
 

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -77,6 +77,12 @@ on:
         default: false
         required: false
 
+      save-container-images:
+        description: Build container images and save them as OCI archive artifacts for deferred push (used by split PR workflows)
+        type: boolean
+        default: false
+        required: false
+
       target-backstage-version:
         description: Target Backstage version for validating OCI tag format in metadata (e.g., "1.42.5")
         type: string
@@ -276,19 +282,13 @@ jobs:
           registry: ${{ inputs.image-repository-prefix }}
 
       - name: Set Plugin Image Repository Prefix
-        if: ${{ inputs.publish-container }}
+        if: ${{ inputs.publish-container || inputs.save-container-images }}
         env:
           IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix }}
-
         id: set-image-tag-name
         shell: bash
         run: |
-          if [[ "${{ inputs.publish-container  }}" ]]
-          then
-            echo "IMAGE_REPOSITORY_PREFIX=$IMAGE_REPOSITORY_PREFIX" >> $GITHUB_OUTPUT
-          else
-            echo "IMAGE_REPOSITORY_PREFIX=" >> $GITHUB_OUTPUT
-          fi
+          echo "IMAGE_REPOSITORY_PREFIX=$IMAGE_REPOSITORY_PREFIX" >> $GITHUB_OUTPUT
 
       - name: Export dynamic plugin packages
         if: ${{ success() }}
@@ -302,6 +302,7 @@ jobs:
           cli-package: ${{inputs.cli-package}}
           image-repository-prefix: ${{ steps.set-image-tag-name.outputs.IMAGE_REPOSITORY_PREFIX }}
           image-tag-prefix: ${{ inputs.image-tag-prefix }}
+          push-container-image: ${{ inputs.publish-container }}
           last-publish-commit: ${{ inputs.last-publish-commit }}
 
       - name: Set artifacts name suffix
@@ -327,6 +328,29 @@ jobs:
           if-no-files-found: warn
           retention-days: ${{ inputs.artifact-retention-days }}
           overwrite: true
+
+      - name: Save container images as OCI archives
+        if: ${{ inputs.save-container-images && steps.export-dynamic.outputs.published-exports != '' }}
+        shell: bash
+        env:
+          PUBLISHED_EXPORTS: ${{ steps.export-dynamic.outputs.published-exports }}
+        run: |
+          mkdir -p container-images
+          while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            name=$(echo "$image" | sed 's|.*/||; s/:/-/')
+            echo "Saving $image -> container-images/${name}.tar"
+            podman save -o "container-images/${name}.tar" "$image"
+          done <<< "$PUBLISHED_EXPORTS"
+
+      - name: Upload container image archives
+        if: ${{ inputs.save-container-images && steps.export-dynamic.outputs.published-exports != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-images${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
+          path: container-images/
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
 
       - name: Upload the project to workflow artifacts on failure
         uses: actions/upload-artifact@v4

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -59,6 +59,12 @@ on:
         default: false
         type: boolean
 
+      save-container-images:
+        description: Build container images and save them as OCI archive artifacts for deferred push (used by split PR workflows)
+        required: false
+        default: false
+        type: boolean
+
       image-repository-prefix:
         description: Repository prefix of the dynamic plugin container images
         type: string
@@ -246,6 +252,7 @@ jobs:
       cli-package: ${{ needs.prepare.outputs.cli-package }}
       upload-project-on-error: ${{ inputs.upload-project-on-error }}
       publish-container: ${{ inputs.publish-container }}
+      save-container-images: ${{ inputs.save-container-images }}
       image-repository-prefix: ${{ inputs.image-repository-prefix }}
       image-tag-prefix: ${{ inputs.image-tag-prefix != '' && inputs.image-tag-prefix || format('bs_{0}__', needs.prepare.outputs.backstage-version) }}
       target-backstage-version: ${{ needs.prepare.outputs.backstage-version }}

--- a/export-dynamic/action.yaml
+++ b/export-dynamic/action.yaml
@@ -64,6 +64,11 @@ inputs:
     default: ""
     required: false
 
+  push-container-image:
+    description: Whether to push built container images to the registry. Set to "false" when saving images for deferred push.
+    default: "true"
+    required: false
+
 outputs:
   failed-exports:
     description: "Failed exports"
@@ -106,7 +111,7 @@ runs:
         INPUTS_SOURCE_PATCH_FILE_NAME: "${{ inputs.source-patch-file-name }}"
         INPUTS_IMAGE_REPOSITORY_PREFIX: "${{ inputs.image-repository-prefix }}"
         INPUTS_IMAGE_TAG_PREFIX: "${{ inputs.image-tag-prefix }}"
-        INPUTS_PUSH_CONTAINER_IMAGE: "true"
+        INPUTS_PUSH_CONTAINER_IMAGE: "${{ inputs.push-container-image }}"
         INPUTS_LAST_PUBLISH_COMMIT: "${{ inputs.last-publish-commit }}"
       # for now always pass this step so we can get all the followup logging steps to still run even if the export fails
       run: ${{ github.action_path }}/export-dynamic.sh || true

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -157,7 +157,8 @@ else
         then
             PLUGIN_NAME=$(jq -r '.name | sub("^@"; "") | sub("[/@]"; "-")' package.json)
             PLUGIN_VERSION="${INPUTS_IMAGE_TAG_PREFIX}$(jq -r '.version' package.json)"
-            PLUGIN_CONTAINER_TAG="${INPUTS_IMAGE_REPOSITORY_PREFIX}/${PLUGIN_NAME}:${PLUGIN_VERSION}"
+            # avoid invalid reference format: repository name must be lowercase error 
+            PLUGIN_CONTAINER_TAG="${INPUTS_IMAGE_REPOSITORY_PREFIX,,}/${PLUGIN_NAME,,}:${PLUGIN_VERSION}"
 
             echo "========== Packaging Container ${PLUGIN_CONTAINER_TAG} =========="
             if run_cli "${PACKAGE_COMMAND[@]}" --tag "${PLUGIN_CONTAINER_TAG}"; then


### PR DESCRIPTION
### Description
Updates the export dynamic script and workflow to allow uploading of podman containers for split workflows (build -> publish)

Also updated export dynamic script to lowercase image registries 


Relates to https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/1671