### PR TITLE
chore(workflows): update action versions across multiple workflows and actions, to prepare for GH node 24 requirement.

### DIFF
--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Validate Inputs
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_WORKSPACE_PATH: ${{ inputs.workspace-path }}
         with:
@@ -94,7 +94,7 @@ jobs:
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
       - name: Download the required-plugins artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         continue-on-error: true
         with:
           name: required-plugins
@@ -277,7 +277,7 @@ jobs:
           fi
 
       - name: Upload compatibility report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: backstage-compatibility-report${{ inputs.artifact-name-suffix }}

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -156,7 +156,7 @@ jobs:
     
     steps:
       - name: Validate Inputs
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_PLUGINS_ROOT: ${{ inputs.plugins-root }}
           INPUT_OVERLAY_ROOT: ${{ inputs.overlay-root }}
@@ -238,7 +238,7 @@ jobs:
           sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - name: Setup Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ inputs.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
@@ -269,7 +269,9 @@ jobs:
 
       - name: Log in to container registry
         if: ${{ inputs.publish-container }}
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           username: ${{ inputs.image-registry-user }}
           password: ${{ secrets.image-registry-password }}
@@ -319,7 +321,7 @@ jobs:
           echo "ARTIFACTS_NAME_SUFFIX=$ARTIFACTS_NAME_SUFFIX" >> $GITHUB_OUTPUT
 
       - name: Upload exported archives to workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !inputs.publish-release-assets && success() && steps.export-dynamic.outputs.workspace-skipped-unchanged-since == 'false' }}
         with:
           name: dynamic plugin packages${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
@@ -329,7 +331,7 @@ jobs:
           overwrite: true
 
       - name: Upload the project to workflow artifacts on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ inputs.upload-project-on-error && (failure() || steps.export-dynamic.outputs.failed-exports) }}
         with:
           name: project root folder${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
@@ -345,7 +347,7 @@ jobs:
 
       - name: Log container image names
         if: ${{ success() && steps.export-dynamic.outputs.published-exports != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_PUBLISHED_EXPORTS: ${{ steps.export-dynamic.outputs.published-exports }}
           INPUT_OVERLAY_ROOT: ${{ inputs.overlay-root }}
@@ -360,7 +362,7 @@ jobs:
 
       - name: Log that the workspace has been skipped
         if: ${{ success() && steps.export-dynamic.outputs.workspace-skipped-unchanged-since != 'false' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_UNCHANGED_SINCE: ${{ steps.export-dynamic.outputs.workspace-skipped-unchanged-since }}
           INPUT_OVERLAY_REPO: ${{ inputs.overlay-repo }}
@@ -377,7 +379,7 @@ jobs:
       
       - name: Check export errors
         if: ${{ success() && steps.export-dynamic.outputs.failed-exports != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_FAILED_EXPORTS: ${{ steps.export-dynamic.outputs.failed-exports }}
           INPUT_PLUGINS_ROOT: ${{ inputs.plugins-root }}
@@ -392,8 +394,10 @@ jobs:
             core.setFailed(`The export for workspace '${overlayRoot}' failed for the following plugins:\n${ failedExports.map(line => line.replace(/^(.*..*)$/gm, replaceExpr)) }`);
 
       - name: Publish exported plugins as GitHub release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         if: ${{ success() && inputs.publish-release-assets }}
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           body:
             Dynamic Plugins for Red Hat Developer Hub ${{ github.ref_name }}, exported from ${{ inputs.plugins-repo }}.

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Validate Inputs
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_WORKSPACE_PATH: ${{ inputs.workspace-path }}
         with:

--- a/.github/workflows/test-validate-metadata.yaml
+++ b/.github/workflows/test-validate-metadata.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -178,7 +178,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -313,7 +313,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 
@@ -363,7 +363,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 24.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
 

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
@@ -484,7 +484,7 @@ jobs:
           fi
 
       - name: Upload workspaces json file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: workspaces
           path: workspaces.json
@@ -507,7 +507,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download workspaces json file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: workspaces
 
@@ -644,7 +644,7 @@ jobs:
           
       - name: Prepare to create PR if necessary
         id: prepare
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_WORKSPACE: ${{ steps.get-workspace-json.outputs.workspace }}
           INPUT_COMMIT_ID: ${{ steps.get-workspace-commit-id.outputs.workspace-commit }}

--- a/export-dynamic/action.yaml
+++ b/export-dynamic/action.yaml
@@ -79,7 +79,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate Inputs
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_PLUGINS_ROOT: ${{ inputs.plugins-root }}
       with:

--- a/update-overlay/action.yaml
+++ b/update-overlay/action.yaml
@@ -64,7 +64,7 @@ runs:
       run: npm install --no-audit --no-fund
     - name: Create PR if necessary
       id: create-pr-if-necessary
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
         INPUT_OVERLAY_REPO: ${{ inputs.overlay-repo }}
         INPUT_PLUGINS_REPO: ${{ inputs.plugins-repo }}


### PR DESCRIPTION
This commit updates various GitHub Actions to their latest versions for to avoid `Node 24`-related warnings, and pins the versions for improved security.

Assisted-by: Cursor