### PR TITLE
Fix incorrect automatic update for the `backstage` workspace.

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -590,16 +590,35 @@ jobs:
                 manifestVersions[pkg.name] = pkg.version;
               }
 
-              // Parse plugins-list.yaml to get active plugin directories
-              const pluginDirs = pluginsListText.trim().split('\n')
-                .filter(line => !line.startsWith('#') && line.trim())
-                .map(line => line.split(':')[0].trim())
-                .filter(Boolean);
-
-              if (pluginDirs.length === 0) {
-                core.warning(`No active plugins found in plugins-list.yaml for branch ${branch}`);
+              // Discover plugin directories from the backstage repo tree at the tag
+              let treeResponse;
+              try {
+                treeResponse = await github.graphql(`
+                  query($owner: String!, $repo: String!) {
+                    repository(owner: $owner, name: $repo) {
+                      tree: object(expression: "${tag}:plugins") {
+                        ... on Tree {
+                          entries { name, type }
+                        }
+                      }
+                    }
+                  }`, { owner: 'backstage', repo: 'backstage' });
+              } catch (e) {
+                core.warning(`Failed to list plugins/ tree from backstage/backstage at ${tag}: ${e.message}`);
                 continue;
               }
+
+              const pluginDirs = (treeResponse.repository?.tree?.entries || [])
+                .filter(e => e.type === 'tree')
+                .filter(e => !e.name.endsWith('-node') && !e.name.endsWith('-common') && !e.name.endsWith('-react'))
+                .map(e => `plugins/${e.name}`);
+
+              if (pluginDirs.length === 0) {
+                core.warning(`No plugin directories found in backstage/backstage at ${tag}`);
+                continue;
+              }
+
+              core.info(`Found ${pluginDirs.length} candidate plugin directories at ${tag}`);
 
               // Batch-fetch package.json files from the backstage repo at the tag ref
               // to resolve actual package names from directories
@@ -638,6 +657,9 @@ jobs:
                   core.warning(`  Invalid package.json at ${dir}: ${e.message}`);
                   continue;
                 }
+
+                if (!pkgJson.name?.startsWith('@backstage/')) continue;
+                if (!(pkgJson.backstage?.role || '').includes('-plugin')) continue;
 
                 const packageName = pkgJson.name;
                 const version = manifestVersions[packageName];

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -153,7 +153,7 @@ module.exports = async ({github, context, core}) => {
           );
 
           if (linesToAdd.length || linesToKeep.length < existingLines.length) {
-            pluginsYamlContent = [...linesToKeep, ...linesToAdd].join('\n'); 
+            pluginsYamlContent = [...linesToKeep, ...linesToAdd].join('\n') + '\n'; 
           } else {
             pluginsYamlContent = response.repository.pluginsList.text;
           }


### PR DESCRIPTION
### Summary

The `inject-backstage` step was reading `plugins-list.yaml` to determine which plugins to process, creating a feedback loop where commented-out and unresolvable entries were silently dropped on each run.
We now discover plugin directories directly from the `backstage/backstage` repo tree at the release tag instead, filtering by `@backstage/ scope`, `backstage.role`, and release manifest presence.

This PR also fixes a missing trailing newline in the `plugins-list.yaml` merge logic.

Assisted-by: Cursor