### PR TITLE
fix(workflows): enhance workspace exclusion logic in `update-plugins-repo-refs` workflow

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -467,7 +467,7 @@ jobs:
 
           # Filter out excluded workspaces
 
-          if [[ -n "${INPUT_EXCLUDE_WORKSPACES}" ]]; then
+          if [[ -n "${INPUT_EXCLUDE_WORKSPACES}" && "$workspaces" != "null" ]]; then
             workspaces=$(echo "$workspaces" | jq --arg exclude "${INPUT_EXCLUDE_WORKSPACES}" '
               with_entries(
                 select(


### PR DESCRIPTION
Updated the condition for filtering excluded workspaces to ensure it only processes non-null workspaces, improving the robustness of the workflow.