### PR TITLE
feat(workflows): introduce computed image tag prefix for metadata validation

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -91,7 +91,15 @@ on:
         description: Optional prefix to prepend to the plugin version in the image tag
         type: string
         required: false
-    
+
+      computed-image-tag-prefix:
+        description: >
+          The computed image tag prefix reflecting backstage compatibility
+          (e.g., "bs_1.48.3__" for compatible, "next__" for incompatible).
+          Used by metadata validation to decide whether OCI tag checks apply.
+        type: string
+        required: false
+
       publish-release-assets:
         description:
           Whether the dynamic plugin archives should be published as GitHub release assets or pushed as workflow
@@ -413,4 +421,4 @@ jobs:
           plugins-root: ${{ github.workspace }}/source-repo/${{inputs.plugins-root}}
           target-backstage-version: ${{ inputs.target-backstage-version }}
           image-repository-prefix: ${{ steps.set-image-tag-name.outputs.IMAGE_REPOSITORY_PREFIX }}
-          image-tag-prefix: ${{ inputs.image-tag-prefix }}
+          computed-image-tag-prefix: ${{ inputs.computed-image-tag-prefix }}

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -271,6 +271,7 @@ jobs:
       publish-container: ${{ inputs.publish-container }}
       image-repository-prefix: ${{ inputs.image-repository-prefix }}
       image-tag-prefix: ${{ inputs.image-tag-prefix != '' && inputs.image-tag-prefix || matrix.workspace.computed-image-tag-prefix }}
+      computed-image-tag-prefix: ${{ matrix.workspace.computed-image-tag-prefix }}
       target-backstage-version: ${{ needs.prepare.outputs.backstage-version }}
       last-publish-commit: ${{ inputs.last-publish-commit }}
       image-registry-user: ${{ inputs.image-registry-user }}

--- a/.github/workflows/test-validate-metadata.yaml
+++ b/.github/workflows/test-validate-metadata.yaml
@@ -399,8 +399,8 @@ jobs:
             message: 'plugins-list.yaml must be a YAML dictionary with plugin paths as keys'
           });
 
-  test-validation-next-prefix-skips-tag:
-    name: Test Validation (next__ prefix skips OCI tag check)
+  test-validation-incompatible-workspace-skips-tag:
+    name: Test Validation (incompatible workspace skips OCI tag check)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -411,7 +411,7 @@ jobs:
         with:
           node-version: 24.x
 
-      - name: Run Validate Metadata with next__ prefix
+      - name: Run Validate Metadata with next__ computed prefix
         id: validate
         uses: ./validate-metadata
         with:
@@ -419,7 +419,7 @@ jobs:
           plugins-root: ${{ env.TEST_DIR }}/source
           target-backstage-version: ${{ env.TARGET_BACKSTAGE_VERSION }}
           image-repository-prefix: ${{ env.IMAGE_REPOSITORY_PREFIX }}
-          image-tag-prefix: next__
+          computed-image-tag-prefix: next__
 
       - name: Verify validation passed despite stale OCI tag
         env:
@@ -432,7 +432,84 @@ jobs:
           const { VALIDATION_PASSED, VALIDATION_ERROR_COUNT, VALIDATION_ERRORS } = process.env;
 
           // Metadata has bs_1.40.0__1.0.0 which doesn't match target 1.42.5,
-          // but with next__ prefix the OCI tag check is skipped
+          // but with next__ computed prefix the OCI tag check is skipped
+          assert.equal(VALIDATION_PASSED, 'true');
+          assert.equal(VALIDATION_ERROR_COUNT, '0');
+          assert.equal(VALIDATION_ERRORS, '[]');
+
+  test-validation-pr-compatible-validates-tag:
+    name: Test Validation (PR build with compatible workspace validates OCI tag)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+
+      - name: Run Validate Metadata with bs_ computed prefix (simulating compatible PR)
+        id: validate
+        uses: ./validate-metadata
+        with:
+          overlay-root: ${{ env.TEST_DIR }}/cases/pass
+          plugins-root: ${{ env.TEST_DIR }}/source
+          target-backstage-version: ${{ env.TARGET_BACKSTAGE_VERSION }}
+          image-repository-prefix: ${{ env.IMAGE_REPOSITORY_PREFIX }}
+          computed-image-tag-prefix: bs_${{ env.TARGET_BACKSTAGE_VERSION }}__
+
+      - name: Verify validation passed (metadata tag matches computed prefix)
+        env:
+          VALIDATION_PASSED: ${{ steps.validate.outputs.validation-passed }}
+          VALIDATION_ERROR_COUNT: ${{ steps.validate.outputs.validation-error-count }}
+          VALIDATION_ERRORS: ${{ steps.validate.outputs.validation-errors }}
+        shell: node {0}
+        run: |
+          import assert from 'node:assert/strict';
+          const { VALIDATION_PASSED, VALIDATION_ERROR_COUNT, VALIDATION_ERRORS } = process.env;
+
+          // Even though a real PR build would use pr_N__ as the image-tag-prefix,
+          // the computed-image-tag-prefix is bs_<target>__ for compatible workspaces,
+          // so OCI tag validation runs and passes against the production tag.
+          assert.equal(VALIDATION_PASSED, 'true');
+          assert.equal(VALIDATION_ERROR_COUNT, '0');
+          assert.equal(VALIDATION_ERRORS, '[]');
+
+  test-validation-pr-incompatible-skips-tag:
+    name: Test Validation (PR build with incompatible workspace skips OCI tag check)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+
+      - name: Run Validate Metadata with next__ computed prefix (simulating incompatible PR)
+        id: validate
+        uses: ./validate-metadata
+        with:
+          overlay-root: ${{ env.TEST_DIR }}/cases/next-prefix-skip
+          plugins-root: ${{ env.TEST_DIR }}/source
+          target-backstage-version: ${{ env.TARGET_BACKSTAGE_VERSION }}
+          image-repository-prefix: ${{ env.IMAGE_REPOSITORY_PREFIX }}
+          computed-image-tag-prefix: next__
+
+      - name: Verify validation passed despite stale OCI tag
+        env:
+          VALIDATION_PASSED: ${{ steps.validate.outputs.validation-passed }}
+          VALIDATION_ERROR_COUNT: ${{ steps.validate.outputs.validation-error-count }}
+          VALIDATION_ERRORS: ${{ steps.validate.outputs.validation-errors }}
+        shell: node {0}
+        run: |
+          import assert from 'node:assert/strict';
+          const { VALIDATION_PASSED, VALIDATION_ERROR_COUNT, VALIDATION_ERRORS } = process.env;
+
+          // PR build of an incompatible workspace: computed prefix is next__,
+          // so OCI tag validation is skipped even though metadata has stale bs_1.40.0__
           assert.equal(VALIDATION_PASSED, 'true');
           assert.equal(VALIDATION_ERROR_COUNT, '0');
           assert.equal(VALIDATION_ERRORS, '[]');

--- a/validate-metadata/action.yaml
+++ b/validate-metadata/action.yaml
@@ -14,8 +14,11 @@ inputs:
     description: Repository prefix for validating OCI reference format in dynamicArtifact
     required: false
     default: ""
-  image-tag-prefix:
-    description: OCI image tag prefix used by the export (e.g., "bs_1.48.3__", "next__", "pr_42__"). When "next__", OCI tag validation is skipped since the workspace is backstage-incompatible.
+  computed-image-tag-prefix:
+    description: >
+      The computed image tag prefix reflecting backstage compatibility
+      (e.g., "bs_1.48.3__" for compatible, "next__" for incompatible).
+      When "next__", OCI tag validation is skipped since the workspace is backstage-incompatible.
     required: false
     default: ""
 
@@ -42,7 +45,7 @@ runs:
         INPUTS_PLUGINS_ROOT: ${{ inputs.plugins-root }}
         INPUTS_TARGET_BACKSTAGE_VERSION: ${{ inputs.target-backstage-version }}
         INPUTS_IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix }}
-        INPUTS_IMAGE_TAG_PREFIX: ${{ inputs.image-tag-prefix }}
+        INPUTS_COMPUTED_IMAGE_TAG_PREFIX: ${{ inputs.computed-image-tag-prefix }}
       run: |
         npm install
         node validate-metadata.ts

--- a/validate-metadata/validate-metadata.ts
+++ b/validate-metadata/validate-metadata.ts
@@ -78,7 +78,7 @@ const OVERLAY_ROOT = process.env.INPUTS_OVERLAY_ROOT;
 const PLUGINS_ROOT = process.env.INPUTS_PLUGINS_ROOT;
 const TARGET_BACKSTAGE_VERSION = process.env.INPUTS_TARGET_BACKSTAGE_VERSION;
 const IMAGE_REPOSITORY_PREFIX = process.env.INPUTS_IMAGE_REPOSITORY_PREFIX || '';
-const IMAGE_TAG_PREFIX = process.env.INPUTS_IMAGE_TAG_PREFIX || '';
+const COMPUTED_IMAGE_TAG_PREFIX = process.env.INPUTS_COMPUTED_IMAGE_TAG_PREFIX || '';
 
 // Validate required environment variables
 if (!OVERLAY_ROOT) {
@@ -362,12 +362,13 @@ function validateOciReference(
 ): void {
   const { reference, tag } = parseOciReference(dynamicArtifact);
 
-  // When the export uses next__ (workspace is backstage-incompatible),
-  // skip the tag prefix check -- the metadata tag is a remnant from the
+  // Skip the tag prefix check when the workspace is backstage-incompatible
+  // (computed prefix is "next__"). The metadata tag is a remnant from the
   // last compatible state and will self-correct on the next compatible update.
-  if (IMAGE_TAG_PREFIX !== 'next__') {
-    const expectedTag = IMAGE_TAG_PREFIX
-      ? `${IMAGE_TAG_PREFIX}${pluginVersion}`
+  // This applies regardless of the build prefix (release or PR).
+  if (COMPUTED_IMAGE_TAG_PREFIX !== 'next__') {
+    const expectedTag = COMPUTED_IMAGE_TAG_PREFIX
+      ? `${COMPUTED_IMAGE_TAG_PREFIX}${pluginVersion}`
       : `bs_${TARGET_BACKSTAGE_VERSION}__${pluginVersion}`;
 
     if (tag !== expectedTag) {


### PR DESCRIPTION
This update adds a new input, `computed-image-tag-prefix`, to workflows for better handling of image tag prefixes based on backstage compatibility. The validation logic is adjusted to utilize this computed prefix, ensuring accurate OCI tag checks for both compatible and incompatible workspaces.

Assisted-by: Cursor