### PR TITLE
chore: do not break lines when generating catalog metadata

### DIFF
--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -215,7 +215,7 @@ module.exports = async ({github, context, core}) => {
       return {
         path: `${workspacePath}/metadata/${entry.name}`,
         mode: '100644',
-        content: doc.toString(),
+        content: doc.toString({ lineWidth: 0 }),
       };
     }
 


### PR DESCRIPTION
### What does this PR do?

chore: do not break lines
Assisted-By: cursor

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

What was wrong
In [create-pr-if-necessary.js](https://github.com/redhat-developer/rhdh-plugin-export-utils/blob/main/update-overlay/create-pr-if-necessary.js), updated metadata is written with doc.toString() with no options. The yaml package defaults to lineWidth: 80, so long scalar values (notably spec.dynamicArtifact OCI URLs) are emitted as double-quoted strings with backslash line continuation, for example:

```
dynamicArtifact: "oci://ghcr.io/...\
  xxxxxxxxx..."
```

That is still valid YAML, but anything that treats the value as a single physical line (or does a naive line-based parse) will break.

Fix
Pass `{ lineWidth: 0 }` so the serializer does not wrap long lines. That keeps dynamicArtifact (and other long fields) on one line.

Change applied here (sibling clone of the utils repo on your machine):


```
create-pr-if-necessary.js
Lines 215-219

      return {
        path: `${workspacePath}/metadata/${entry.name}`,
        mode: '100644',
        content: doc.toString({ lineWidth: 0 }),
      };
```

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.