### PR TITLE
feat(workflows): add 'force' input to bypass workspace checks

### DIFF
--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -47,6 +47,11 @@ on:
         required: false
         default: ""
 
+      force:
+        type: boolean
+        required: false
+        default: false
+
 jobs:
  
   prepare:
@@ -1081,6 +1086,7 @@ jobs:
           workspace-json: ${{ steps.prepare.outputs.workspace-json }}
           allow-workspace-addition: ${{ inputs.allow-workspace-addition }}
           pr-to-update: ${{ inputs.pr-to-update }}
+          force: ${{ inputs.force }}
     
     permissions:
       contents: write

--- a/update-overlay/action.yaml
+++ b/update-overlay/action.yaml
@@ -55,6 +55,11 @@ inputs:
     required: false
     default: "{}"
 
+  force:
+    description: "Bypass 'source already up-to-date' skip, re-apply metadata tag updates"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -79,6 +84,7 @@ runs:
         INPUT_ALLOW_WORKSPACE_ADDITION: ${{ inputs.allow-workspace-addition }}
         INPUT_PR_TO_UPDATE: ${{ inputs.pr-to-update }}
         INPUT_WORKSPACE_JSON: ${{ inputs.workspace-json }}
+        INPUT_FORCE: ${{ inputs.force }}
 
       with:
         retries: 4

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -14,6 +14,7 @@ module.exports = async ({github, context, core}) => {
   const pluginDirectories = core.getInput('plugin_directories');
   const allowWorkspaceAddition = core.getInput('allow_workspace_addition');
   const prToUpdate = core.getInput('pr_to_update');
+  const force = core.getInput('force') === 'true';
   const workspaceJson = JSON.parse(core.getInput('workspace_json') || '{}');
   /** @type {Record<string, string>} */
   const pluginVersions = {};
@@ -250,10 +251,13 @@ module.exports = async ({github, context, core}) => {
 
     const workspaceCheck = await checkWorkspace(overlayRepoBranchName);
     if (workspaceCheck.status === 'sourceEqual') {
-      core.info(
-        `Workspace skipped: Workspace ${workspaceName} already exists on branch ${overlayRepoBranchName} with the same commit ${shortRef(workspaceCommit)}`,
-      );
-      return;
+      if (!force) {
+        core.info(
+          `Workspace skipped: Workspace ${workspaceName} already exists on branch ${overlayRepoBranchName} with the same commit ${shortRef(workspaceCommit)}`,
+        );
+        return;
+      }
+      core.info(`Source is equal but proceeding (force mode) to re-apply metadata updates`);
     }
 
     core.info(`Checking pull request existence`);


### PR DESCRIPTION
This commit introduces a new input parameter, 'force', to the workflows and action files, allowing users to bypass the 'source already up-to-date' check. When enabled, the workflow will proceed with re-applying metadata tag updates even if the workspace is deemed up-to-date. This enhancement provides greater flexibility in managing workspace updates.

Assisted-by: Cursor