### PR TITLE
fix(update-overlay): improve handling of overridden `backstage.json` logic

### DIFF
--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -492,9 +492,11 @@ Workspace reference should be manually set to commit ${workspaceCommit}.`,
     
     let deleteBackstageJson = false;
     const backstageVersionOverride = prBranchExists ? prContentCheck?.backstageVersionOverride : workspaceCheck.backstageVersionOverride;
-    if (!!backstageVersionOverride && backstageVersionOverride !== backstageVersion) {
+    if (!!backstageVersionOverride && backstageVersionOverride !== backstageVersion && backstageVersionOverride !== targetBackstageVersion) {
       deleteBackstageJson = true;
-      core.info(`Deleting the overridden \`backstage.json\` because it's out-of-sync (\`${workspaceCheck.backstageVersionOverride}\`) with the backstage version of the new source commit (\`${backstageVersion}\`)`);
+      core.info(`Deleting the overridden \`backstage.json\` because it's out-of-sync (\`${workspaceCheck.backstageVersionOverride}\`) with both the backstage version of the new source commit (\`${backstageVersion}\`) and the target backstage version (\`${targetBackstageVersion}\`)`);
+    } else if (!!backstageVersionOverride && backstageVersionOverride === targetBackstageVersion && backstageVersionOverride !== backstageVersion) {
+      core.info(`Keeping overridden \`backstage.json\` (\`${backstageVersionOverride}\`) because it matches the target backstage version`);
     }
     
     const metadataEntries = (prBranchExists ? prContentCheck?.metadataEntries : workspaceCheck.metadataEntries) ?? [];


### PR DESCRIPTION
This commit enhances the logic for managing the `backstage.json` file by adding conditions to check if the overridden version matches the target backstage version. It ensures that the overridden file is only deleted when it is out-of-sync with both the new source commit and the target version, while also providing informative logging for both deletion and retention scenarios.

Assisted-by: Cursor