### PR TITLE
fix(update-overlay): refine PR handling with force option

### DIFF
--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -373,10 +373,14 @@ module.exports = async ({github, context, core}) => {
       prContentCheck = await checkWorkspace(targetPRBranchName);
       switch (prContentCheck.status) {
         case 'sourceEqual':
-          core.info(
-            `Workspace skipped: Pull request #${existingPR.number} for workspace ${workspaceName} based on branch ${targetPRBranchName} already exists with the same commit ${shortRef(workspaceCommit)}`,
-          );
-          return;
+          if (!force) {
+            core.info(
+              `Workspace skipped: Pull request #${existingPR.number} for workspace ${workspaceName} based on branch ${targetPRBranchName} already exists with the same commit ${shortRef(workspaceCommit)}`,
+            );
+            return;
+          }
+          core.info(`PR branch source is equal but proceeding (force mode) to re-apply metadata updates on PR #${existingPR.number}`);
+          break;
 
         case 'sourceNeedsUpdate':
           if (prToUpdate === '') {


### PR DESCRIPTION
This commit updates the logic in the `create-pr-if-necessary.js` file to enhance the handling of pull requests when the source branch is equal. It introduces a conditional check for the 'force' option, allowing users to proceed with metadata updates even if the existing pull request is up-to-date. Informative logging is added to clarify the behavior in both forced and non-forced scenarios.

Assisted-by: Cursor