### PR TITLE
fix(export)-dynamic): post-process `supported-versions` instead of overriding `backstage.json`

### DIFF
--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -89,15 +89,13 @@ if [[ "${skipWorkspace}" == "true" ]]
 then
     echo "Skipping workspace since it didn't change since last published commit (${INPUTS_LAST_PUBLISH_COMMIT})"
 else
-    if [[ -f "${workspaceOverlayFolder}/backstage.json" ]]
-    then
-        echo "Overriding backstage.json file before exporting plugins to override the supportedVersions package field."
-        if [[ -f "backstage.json" ]]
-        then
-            cp -fv "backstage.json" "backstage.json.save"
-            trap "mv -fv 'backstage.json.save' 'backstage.json'" EXIT
+    overlay_backstage_json="${workspaceOverlayFolder}/backstage.json"
+    overlay_supported_version=""
+    if [[ -f "$overlay_backstage_json" ]]; then
+        overlay_supported_version=$(jq -r '.version' "$overlay_backstage_json")
+        if [[ "$overlay_supported_version" == "null" ]]; then
+            overlay_supported_version=""
         fi
-        cp -fv "${workspaceOverlayFolder}/backstage.json" "backstage.json"
     fi
 
     # We use '|| [[ -n "$plugin" ]]' to catch the last line even if it lacks a newline.
@@ -149,6 +147,14 @@ else
             set -e
             popd > /dev/null
             continue
+        fi
+
+        if [[ -n "$overlay_supported_version" ]] && [[ -f "dist-dynamic/package.json" ]]; then
+            echo "  Setting supported-versions to ${overlay_supported_version} from overlay backstage.json"
+            jq --arg ver "$overlay_supported_version" \
+               '.backstage["supported-versions"] = $ver' \
+               dist-dynamic/package.json > dist-dynamic/package.json.tmp \
+               && mv dist-dynamic/package.json.tmp dist-dynamic/package.json
         fi
         echo
 


### PR DESCRIPTION
## Problem

The overlay's `backstage.json` is copied over the workspace's before running `rhdh-cli plugin export`, so that `backstage.supported-versions` in the exported `dist-dynamic/package.json` reflects the RHDH target version.

Since rhdh-cli 1.10.6, the CLI also reads `backstage.json` to resolve `backstage:^` dependencies via the Backstage release manifest. The override causes all `backstage:^` dependencies to resolve against the wrong manifest (e.g. `@backstage/backend-plugin-api: ^1.8.0` from 1.49.x instead of `^1.4.4` from 1.44.2).

## Fix

- Fixes https://redhat.atlassian.net/browse/RHIDP-13562
- Remove the pre-export `backstage.json` override
- Extract the overlay version once before the plugin loop
- Patch `backstage.supported-versions` in `dist-dynamic/package.json` after each successful export

This decouples dependency resolution (which needs the source version) from supported-versions metadata (which needs the RHDH target version).

## Scope

Single file change: `export-dynamic/export-dynamic.sh`. No overlay repo or rhdh-cli changes needed. Compatible with all rhdh-cli versions.