### PR TITLE
chore: skip entries in plugins-list.yaml...

### DIFF
--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -118,6 +118,11 @@ else
         # shellcheck disable=SC2001
         args=$(echo "$plugin" | sed 's/^\(^[^:]*\): *\(.*\)$/\2/')
         
+        # check if folder exists; if not, skip this package
+        if [ ! -d "$pluginPath" ]; then
+            echo "Skip missing package folder $pluginPath"
+            continue
+        fi
         pushd "$pluginPath" > /dev/null
         
         if [[ "$(grep -e '"role" *: *"frontend-plugin' package.json)" != "" ]]


### PR DESCRIPTION
### What does this PR do?

chore: skip entries in plugins-list.yaml which don't map to an existing folder (because they were deleted downstream)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.