### PR TITLE
chore: add `/override-backstage` command to the help msg

### DIFF
--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Validate Inputs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_WORKSPACE_PATH: ${{ inputs.workspace-path }}
         with:
@@ -94,7 +94,7 @@ jobs:
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
       - name: Download the required-plugins artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: required-plugins
@@ -251,7 +251,7 @@ jobs:
               echo '    - *__Backstage version history available__*: A `BS Version History` link might be available in column 4: in the workspace source repository, it points to the list of commits touching the `backstage.json` file. This would help you finding out whether this workspace has a commit that has been published for the target backstage version.'
               echo '    - *__No info available__*: If no information is is provided in column 4, the `backstage.json` probably does not exist in workspace sources. You would have to look deeper into the newer commits of workspace sources, possibly in the low-level dependencies in the `package.json` files, to find out a commit with an underlying backstage version compatible with the target backstage version.'
               echo '  - Then, in the overlay repository, update the `repo-ref` field of the `source.json` file to the new source commit, and remember to also change the `repo-backstage-version` field to the corresponding compatible backstage version.'
-              echo '- *__No compatible commit :__* If the workspace sources contain __*no compatible newer commit*__ ( == a commit that provides a `backstage.json` version compatible with the target backstage), but the current workspace commit is known to work with the target backstage version, then you can override the declared backstage version compatibility for this workspace commit in the overlay repository: add a `backstage.json` file at the root of the overlay workspace folder with the desired target backstage version. This would require full testing of the workspace plugins on the target backstage though.'
+              echo '- *__No compatible commit :__* If the workspace sources contain __*no compatible newer commit*__ ( == a commit that provides a `backstage.json` version compatible with the target backstage), but the current workspace commit is known to work with the target backstage version, then you can override the declared backstage version compatibility for this workspace commit in the overlay repository using the `/override-backstage` command which will add a `backstage.json` file at the root of the overlay workspace folder with the desired target backstage version. This would require full testing of the workspace plugins on the target backstage though.'
               echo ""
               echo "</details>"
               } | tee -a "$REPORT_FILE" >> $GITHUB_STEP_SUMMARY
@@ -277,7 +277,7 @@ jobs:
           fi
 
       - name: Upload compatibility report
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: backstage-compatibility-report${{ inputs.artifact-name-suffix }}

--- a/update-overlay/create-pr-if-necessary.js
+++ b/update-overlay/create-pr-if-necessary.js
@@ -211,6 +211,13 @@ module.exports = async ({github, context, core}) => {
         }
       }
 
+      const currentSupportedVersions = doc.getIn(['spec', 'backstage', 'supportedVersions']);
+      if (currentSupportedVersions != null && String(currentSupportedVersions) !== targetBackstageVersion) {
+        doc.setIn(['spec', 'backstage', 'supportedVersions'], targetBackstageVersion);
+        core.info(`  Updated supportedVersions to ${targetBackstageVersion} in ${entry.name}`);
+        modified = true;
+      }
+
       if (!modified) return null;
 
       return {


### PR DESCRIPTION
### Description
Small update to error message when workspace incompatibility is detected 
Also updates update-overlay/create-pr-if-necessary.js to update the `supportedVersions` field for the metadata with the latest version.json version 

Fixes [RHIDP-13378](https://redhat.atlassian.net/browse/RHIDP-13378)
Related to https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2471