### PR TITLE
chore(metadata-validation): Validate-metadata now check presence of metadata files.

### DIFF
--- a/.github/workflows/test-validate-metadata.yaml
+++ b/.github/workflows/test-validate-metadata.yaml
@@ -399,6 +399,43 @@ jobs:
             message: 'plugins-list.yaml must be a YAML dictionary with plugin paths as keys'
           });
 
+  test-validation-missing-metadata-warning:
+    name: Test Validation (Missing Metadata Warning Only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+
+      - name: Run Validate Metadata
+        id: validate
+        uses: ./validate-metadata
+        with:
+          overlay-root: ${{ env.TEST_DIR }}/cases/missing-metadata-warning
+          plugins-root: ${{ env.TEST_DIR }}/source
+          target-backstage-version: ${{ env.TARGET_BACKSTAGE_VERSION }}
+          image-repository-prefix: ${{ env.IMAGE_REPOSITORY_PREFIX }}
+
+      - name: Verify validation passed with warning-only coverage result
+        env:
+          STEP_OUTCOME: ${{ steps.validate.outcome }}
+          VALIDATION_PASSED: ${{ steps.validate.outputs.validation-passed }}
+          VALIDATION_ERROR_COUNT: ${{ steps.validate.outputs.validation-error-count }}
+          VALIDATION_ERRORS: ${{ steps.validate.outputs.validation-errors }}
+        shell: node {0}
+        run: |
+          import assert from 'node:assert/strict';
+          const { STEP_OUTCOME, VALIDATION_PASSED, VALIDATION_ERROR_COUNT, VALIDATION_ERRORS } = process.env;
+
+          assert.equal(STEP_OUTCOME, 'success');
+          assert.equal(VALIDATION_PASSED, 'true');
+          assert.equal(VALIDATION_ERROR_COUNT, '0');
+          assert.equal(VALIDATION_ERRORS, '[]');
+
   test-validation-incompatible-workspace-skips-tag:
     name: Test Validation (incompatible workspace skips OCI tag check)
     runs-on: ubuntu-latest

--- a/validate-metadata/test/cases/missing-metadata-warning/metadata/test-plugin.yaml
+++ b/validate-metadata/test/cases/missing-metadata-warning/metadata/test-plugin.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: test-plugin
+  namespace: rhdh
+spec:
+  packageName: '@test-org/plugin-test'
+  dynamicArtifact: oci://ghcr.io/test-org/test-repo/test-org-plugin-test:bs_1.42.5__1.0.0!test-org-plugin-test
+  version: 1.0.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.42.5

--- a/validate-metadata/test/cases/missing-metadata-warning/plugins-list.yaml
+++ b/validate-metadata/test/cases/missing-metadata-warning/plugins-list.yaml
@@ -1,0 +1,2 @@
+plugins/test-plugin:
+plugins/test-backend:

--- a/validate-metadata/validate-metadata.ts
+++ b/validate-metadata/validate-metadata.ts
@@ -38,6 +38,11 @@ interface MismatchError {
 }
 
 type ValidationError = MissingFileError | ParseError | MissingFieldError | UnknownPackageError | MismatchError;
+interface MissingMetadataWarning {
+  kind: 'missing-metadata';
+  packageName: string;
+  message: string;
+}
 
 type Result<T, E> = { value: T; error?: undefined } | { value?: undefined; error: E };
 
@@ -155,13 +160,20 @@ for (const metadataFile of metadataFiles) {
   }
 }
 
-reportErrorsAndExit(errors);
+const metadataPackageNames = collectMetadataPackageNames(metadataFiles);
+const warnings = findMissingMetadataWarnings(pluginsMapping, metadataPackageNames);
+
+for (const warning of warnings) {
+  console.log(`::warning::${warning.message}`);
+}
+
+reportErrorsAndExit(errors, warnings);
 
 /**
  * Report validation errors to GitHub Actions and exit
  */
-function reportErrorsAndExit(errors: ValidationError[]): never {
-  const summary = formatErrorsForSummary(errors);
+function reportErrorsAndExit(errors: ValidationError[], warnings: MissingMetadataWarning[] = []): never {
+  const summary = formatErrorsForSummary(errors, warnings);
   const githubStepSummary = process.env.GITHUB_STEP_SUMMARY;
   if (githubStepSummary) {
     fs.appendFileSync(githubStepSummary, `\n${summary}\n`);
@@ -188,9 +200,19 @@ function reportErrorsAndExit(errors: ValidationError[]): never {
 /**
  * Format errors for GitHub Actions summary
  */
-function formatErrorsForSummary(errors: ValidationError[]): string {
+function formatErrorsForSummary(errors: ValidationError[], warnings: MissingMetadataWarning[]): string {
+  let warningSummary = '';
+  if (warnings.length > 0) {
+    warningSummary += '## ⚠️ Metadata Coverage Warnings\n\n';
+    warningSummary += 'The following plugins are present in `plugins-list.yaml` but missing matching files in `metadata/`:\n\n';
+    for (const warning of warnings) {
+      warningSummary += `- \`${warning.packageName}\`\n`;
+    }
+    warningSummary += '\n';
+  }
+
   if (errors.length === 0) {
-    return '## ✅ Metadata Validation Passed\n\nAll metadata files are consistent with their corresponding plugin packages.';
+    return `## ✅ Metadata Validation Passed\n\nAll metadata files are consistent with their corresponding plugin packages.\n\n${warningSummary}`.trim();
   }
   
   let summary = '## ❌ Metadata Validation Failed\n\n';
@@ -204,7 +226,7 @@ function formatErrorsForSummary(errors: ValidationError[]): string {
     summary += `| ${fileName} | ${error.kind} | ${escapedMessage} |\n`;
   }
   
-  return summary;
+  return `${summary}\n${warningSummary}`.trim();
 }
 
 /**
@@ -238,6 +260,50 @@ function parsePluginsList(pluginsListPath: string): Result<string[], ValidationE
   }
   
   return { value: Object.keys(pluginsList) };
+}
+
+/**
+ * Collect package names declared in metadata files.
+ */
+function collectMetadataPackageNames(metadataFiles: string[]): Set<string> {
+  const packageNames = new Set<string>();
+
+  for (const metadataFile of metadataFiles) {
+    const { value: rawMetadata } = parseYamlFile(metadataFile);
+    if (!rawMetadata || typeof rawMetadata !== 'object') {
+      continue;
+    }
+
+    const spec = (rawMetadata as Metadata).spec;
+    const packageName = spec?.packageName;
+    if (packageName) {
+      packageNames.add(packageName);
+    }
+  }
+
+  return packageNames;
+}
+
+/**
+ * Warn when plugins listed in plugins-list.yaml have no metadata file.
+ */
+function findMissingMetadataWarnings(
+  pluginsMapping: Map<string, PluginInfo>,
+  metadataPackageNames: Set<string>
+): MissingMetadataWarning[] {
+  const warnings: MissingMetadataWarning[] = [];
+
+  for (const packageName of pluginsMapping.keys()) {
+    if (!metadataPackageNames.has(packageName)) {
+      warnings.push({
+        kind: 'missing-metadata',
+        packageName,
+        message: `Metadata file not found for package "${packageName}"`,
+      });
+    }
+  }
+
+  return warnings;
 }
 
 /**


### PR DESCRIPTION
Modifies validate-metadata action: it searches for plugins from plugin-list.yaml with no metadata files attached and prints a warning message a with list of these.

Signed-off-by: rostalan <rlan@redhat.com>

Assisted-by: Cursor