### PR TITLE
fix(workflows): accept plugin sources on a higher Backstage patch version

### DIFF
--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -93,6 +93,25 @@ jobs:
           ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
+      - name: Resolve export-utils ref
+        id: export-utils-ref
+        run: |
+          ref="${GITHUB_WORKFLOW_REF##*@}"
+          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
+          then
+            ref="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout export-utils compatibility helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: redhat-developer/rhdh-plugin-export-utils
+          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          path: _export-utils
+          sparse-checkout: common/scripts/backstage-version-compatible.sh
+          sparse-checkout-cone-mode: false
+
       - name: Download the required-plugins artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
@@ -109,6 +128,8 @@ jobs:
           INPUT_OVERLAY_REPO_REF: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
         run: |
           npm install semver -g
+          # shellcheck source=common/scripts/backstage-version-compatible.sh
+          source _export-utils/common/scripts/backstage-version-compatible.sh
 
           if [[ "${{ inputs.debug }}" == "true" ]]
           then
@@ -153,7 +174,7 @@ jobs:
               if [[ "${workspaceBackstageVersion}" == "" ]]
               then
                 incompatibleVersion="*not found*"
-              elif [[ "${targetBackstageVersion}" != "$(semver -r ~${workspaceBackstageVersion} ${targetBackstageVersion})" ]]
+              elif ! backstage_versions_exact_match "${workspaceBackstageVersion}" "${targetBackstageVersion}"
               then
                 incompatibleVersion="${sourceBackstageVersion}"
                 if [[ "${incompatibleVersion}" == "" ]]

--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -174,7 +174,7 @@ jobs:
               if [[ "${workspaceBackstageVersion}" == "" ]]
               then
                 incompatibleVersion="*not found*"
-              elif ! backstage_versions_compatible "${workspaceBackstageVersion}" "${targetBackstageVersion}"
+              elif ! backstage_versions_exact_match "${workspaceBackstageVersion}" "${targetBackstageVersion}"
               then
                 incompatibleVersion="${sourceBackstageVersion}"
                 if [[ "${incompatibleVersion}" == "" ]]

--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -174,7 +174,7 @@ jobs:
               if [[ "${workspaceBackstageVersion}" == "" ]]
               then
                 incompatibleVersion="*not found*"
-              elif ! backstage_versions_exact_match "${workspaceBackstageVersion}" "${targetBackstageVersion}"
+              elif ! backstage_versions_minor_match "${workspaceBackstageVersion}" "${targetBackstageVersion}"
               then
                 incompatibleVersion="${sourceBackstageVersion}"
                 if [[ "${incompatibleVersion}" == "" ]]

--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -174,7 +174,7 @@ jobs:
               if [[ "${workspaceBackstageVersion}" == "" ]]
               then
                 incompatibleVersion="*not found*"
-              elif ! backstage_versions_exact_match "${workspaceBackstageVersion}" "${targetBackstageVersion}"
+              elif ! backstage_versions_compatible "${workspaceBackstageVersion}" "${targetBackstageVersion}"
               then
                 incompatibleVersion="${sourceBackstageVersion}"
                 if [[ "${incompatibleVersion}" == "" ]]

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -243,11 +243,11 @@ jobs:
                   workspaceBackstageVersion=$(jq -r '.version' "${d}/backstage.json")
                 fi
 
-                # Use bs_<target>__ prefix only when this workspace is on the same
-                # major.minor line as the target (patch suffixes are ignored)
+                # Use bs_<target>__ prefix only for same major.minor (exact).
+                # Best-effort (older minor) workspaces keep next__ until overridden.
                 wsTagPrefix="next__"
                 if [[ "${workspaceBackstageVersion}" != "" ]] && \
-                   backstage_versions_compatible "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
+                   backstage_versions_exact_match "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
                 then
                   wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}__"
                 fi

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -247,7 +247,7 @@ jobs:
                 # Best-effort (older minor) workspaces keep next__ until overridden.
                 wsTagPrefix="next__"
                 if [[ "${workspaceBackstageVersion}" != "" ]] && \
-                   backstage_versions_exact_match "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
+                   backstage_versions_minor_match "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
                 then
                   wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}__"
                 fi

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -149,6 +149,25 @@ jobs:
           ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
+      - name: Resolve export-utils ref
+        id: export-utils-ref
+        run: |
+          ref="${GITHUB_WORKFLOW_REF##*@}"
+          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
+          then
+            ref="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout export-utils compatibility helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: redhat-developer/rhdh-plugin-export-utils
+          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          path: _export-utils
+          sparse-checkout: common/scripts/backstage-version-compatible.sh
+          sparse-checkout-cone-mode: false
+
       - name: Set environment variables
         id: set-env-vars
         shell: bash {0}
@@ -190,6 +209,9 @@ jobs:
           fi
           echo ""
 
+          # shellcheck source=common/scripts/backstage-version-compatible.sh
+          source _export-utils/common/scripts/backstage-version-compatible.sh
+
           workspacePath=''
           if [[ "${INPUT_WORKSPACE_PATH}" != "" ]]
           then
@@ -222,10 +244,10 @@ jobs:
                 fi
 
                 # Use bs_<target>__ prefix only when this workspace is compatible
-                # with the target backstage version (semver tilde range match)
+                # with the target backstage version (same major.minor line)
                 wsTagPrefix="next__"
                 if [[ "${workspaceBackstageVersion}" != "" ]] && \
-                   [[ "${TARGET_BACKSTAGE_VERSION}" == "$(semver -r "~${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}")" ]]
+                   backstage_versions_exact_match "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
                 then
                   wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}__"
                 fi

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -243,11 +243,11 @@ jobs:
                   workspaceBackstageVersion=$(jq -r '.version' "${d}/backstage.json")
                 fi
 
-                # Use bs_<target>__ prefix only when this workspace is compatible
-                # with the target backstage version (same major.minor line)
+                # Use bs_<target>__ prefix only when this workspace is on the same
+                # major.minor line as the target (patch suffixes are ignored)
                 wsTagPrefix="next__"
                 if [[ "${workspaceBackstageVersion}" != "" ]] && \
-                   backstage_versions_exact_match "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
+                   backstage_versions_compatible "${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}"
                 then
                   wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}__"
                 fi

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -514,13 +514,11 @@ jobs:
                 pluginName=$(echo ${plugin} | jq -r '.name')
                 backstageVersion=$(echo ${plugin} | jq -r '.backstageVersion')
                 version=$(echo ${plugin} | jq -r '.version')
+                # Same major.minor line only (patch ignored). Older/newer minors are not selected.
                 matchType=""
-                if backstage_versions_exact_match "${backstageVersion}" "${targetBackstageVersion}"
+                if backstage_versions_compatible "${backstageVersion}" "${targetBackstageVersion}"
                 then
                   matchType="exact"
-                elif backstage_versions_best_effort_match "${backstageVersion}" "${targetBackstageVersion}"
-                then
-                  matchType="best-effort"
                 fi
                 if [[ "${matchType}" == "" ]]
                 then
@@ -532,10 +530,6 @@ jobs:
                 then
                   matchTypes[${pluginName}]="${matchType}"
                   matchBackstageVersions[${pluginName}]="${backstageVersion}"
-                elif [[ "${matchTypes[${pluginName}]}" != "${matchType}" ]]
-                then
-                  verbose "    Skipping published plugin ${pluginName}@${version} for branch ${overlayRepoBranch} (with '${matchType}' backstage compatibility type), because a newer plugin version has already been selected with a different backstage compatibility type (${matchTypes[${pluginName}]})"
-                  continue
                 elif [[ "${backstageVersion}" != "${matchBackstageVersions[${pluginName}]}" ]]
                 then
                   verbose "    Skipping published plugin ${pluginName}@${version} for branch ${overlayRepoBranch} (compatible with backstage ${targetBackstageVersion}), because a newer plugin version has already been selected with a different underlying Backstage version (${matchBackstageVersions[${pluginName}]})"

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -71,6 +71,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Resolve export-utils ref
+        id: export-utils-ref
+        run: |
+          ref="${GITHUB_WORKFLOW_REF##*@}"
+          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
+          then
+            ref="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout export-utils compatibility helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: redhat-developer/rhdh-plugin-export-utils
+          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          path: _export-utils
+          sparse-checkout: common/scripts/backstage-version-compatible.sh
+          sparse-checkout-cone-mode: false
+
       - name: Get published community plugins
         id: get-published-community-plugins
         shell: bash {0}
@@ -106,6 +125,8 @@ jobs:
 
           set -o pipefail
           npm install semver -g
+          # shellcheck source=common/scripts/backstage-version-compatible.sh
+          source _export-utils/common/scripts/backstage-version-compatible.sh
           overlayRepoBranchesString=$(gh api repos/${INPUT_OVERLAY_REPO}/branches --paginate | jq -r --arg INPUT_RELEASE_BRANCH_PATTERN "${INPUT_RELEASE_BRANCH_PATTERN}" --arg INPUT_SINGLE_BRANCH "${INPUT_SINGLE_BRANCH}" '.[].name | select(. == $INPUT_SINGLE_BRANCH or test($INPUT_RELEASE_BRANCH_PATTERN))')
           if [ $? -ne 0 ]
           then
@@ -494,10 +515,10 @@ jobs:
                 backstageVersion=$(echo ${plugin} | jq -r '.backstageVersion')
                 version=$(echo ${plugin} | jq -r '.version')
                 matchType=""
-                if [[ "${targetBackstageVersion}" == "$(semver -r ~${backstageVersion} ${targetBackstageVersion})" ]]
+                if backstage_versions_exact_match "${backstageVersion}" "${targetBackstageVersion}"
                 then
                   matchType="exact"
-                elif [[ "${targetBackstageVersion}" == "$(semver -r ^${backstageVersion} ${targetBackstageVersion})" ]]
+                elif backstage_versions_best_effort_match "${backstageVersion}" "${targetBackstageVersion}"
                 then
                   matchType="best-effort"
                 fi

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -517,7 +517,7 @@ jobs:
                 # Exact = same major.minor (patch ignored). Best-effort = older
                 # source minor that may still run on the newer target (smoke/e2e gated).
                 matchType=""
-                if backstage_versions_exact_match "${backstageVersion}" "${targetBackstageVersion}"
+                if backstage_versions_minor_match "${backstageVersion}" "${targetBackstageVersion}"
                 then
                   matchType="exact"
                 elif backstage_versions_best_effort_match "${backstageVersion}" "${targetBackstageVersion}"

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -514,11 +514,15 @@ jobs:
                 pluginName=$(echo ${plugin} | jq -r '.name')
                 backstageVersion=$(echo ${plugin} | jq -r '.backstageVersion')
                 version=$(echo ${plugin} | jq -r '.version')
-                # Same major.minor line only (patch ignored). Older/newer minors are not selected.
+                # Exact = same major.minor (patch ignored). Best-effort = older
+                # source minor that may still run on the newer target (smoke/e2e gated).
                 matchType=""
-                if backstage_versions_compatible "${backstageVersion}" "${targetBackstageVersion}"
+                if backstage_versions_exact_match "${backstageVersion}" "${targetBackstageVersion}"
                 then
                   matchType="exact"
+                elif backstage_versions_best_effort_match "${backstageVersion}" "${targetBackstageVersion}"
+                then
+                  matchType="best-effort"
                 fi
                 if [[ "${matchType}" == "" ]]
                 then
@@ -530,6 +534,10 @@ jobs:
                 then
                   matchTypes[${pluginName}]="${matchType}"
                   matchBackstageVersions[${pluginName}]="${backstageVersion}"
+                elif [[ "${matchTypes[${pluginName}]}" != "${matchType}" ]]
+                then
+                  verbose "    Skipping published plugin ${pluginName}@${version} for branch ${overlayRepoBranch} (with '${matchType}' backstage compatibility type), because a newer plugin version has already been selected with a different backstage compatibility type (${matchTypes[${pluginName}]})"
+                  continue
                 elif [[ "${backstageVersion}" != "${matchBackstageVersions[${pluginName}]}" ]]
                 then
                   verbose "    Skipping published plugin ${pluginName}@${version} for branch ${overlayRepoBranch} (compatible with backstage ${targetBackstageVersion}), because a newer plugin version has already been selected with a different underlying Backstage version (${matchBackstageVersions[${pluginName}]})"

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -3,7 +3,7 @@
 # Shared Backstage version compatibility helpers for overlay automation workflows.
 #
 # Exact minor match: same major.minor line (patch .z treated as equivalent).
-#   Example: source 1.52.1 matches target 1.52.0.
+#   Example: source 1.52.1 matches target 1.52.0 and 1.52.0 matches target 1.52.1
 #
 # Best-effort match: target is a newer minor/patch on the same major line
 #   (semver caret). Used by discovery to open review/test PRs for older plugins

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -11,8 +11,11 @@
 backstage_versions_exact_match() {
   local source="$1"
   local target="$2"
-  [[ "${target}" == "$(semver -r "~${source}" "${target}")" ]] ||
-    [[ "${source}" == "$(semver -r "~${target}" "${source}")" ]]
+  if [[ "${target}" == "$(semver -r "~${source}" "${target}")" ]] ||
+    [[ "${source}" == "$(semver -r "~${target}" "${source}")" ]]; then
+    return 0
+  fi
+  return 1
 }
 
 # Best-effort match: target satisfies the caret range of an older source line.
@@ -20,13 +23,19 @@ backstage_versions_exact_match() {
 backstage_versions_best_effort_match() {
   local source="$1"
   local target="$2"
-  [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]
+  if [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]; then
+    return 0
+  fi
+  return 1
 }
 
 # Combined check used by publish/compatibility validation.
 backstage_versions_compatible() {
   local source="$1"
   local target="$2"
-  backstage_versions_exact_match "${source}" "${target}" ||
-    backstage_versions_best_effort_match "${source}" "${target}"
+  if backstage_versions_exact_match "${source}" "${target}" ||
+    backstage_versions_best_effort_match "${source}" "${target}"; then
+    return 0
+  fi
+  return 1
 }

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -2,39 +2,32 @@
 
 # Shared Backstage version compatibility helpers for overlay automation workflows.
 #
+# Compatibility means the same major.minor line (e.g. 1.52.*). Patch suffixes
+# are ignored in either direction — 1.52.1 matches target 1.52.0 and vice versa.
+# Different minors are not treated as compatible (1.49.x does not match 1.52.x).
+#
 # Usage:
 #   source common/scripts/backstage-version-compatible.sh
-#   backstage_versions_exact_match "1.52.1" "1.52.0" && echo exact
+#   backstage_versions_compatible "1.52.1" "1.52.0" && echo compatible
 
-# Exact match: same major.minor line, regardless of patch direction.
-# Example: 1.52.1 is compatible with target 1.52.0.
-backstage_versions_exact_match() {
-  local source="$1"
-  local target="$2"
-  if [[ "${target}" == "$(semver -r "~${source}" "${target}")" ]] ||
-    [[ "${source}" == "$(semver -r "~${target}" "${source}")" ]]; then
+# Extract major.minor from a semver-like string (x.y or x.y.z).
+backstage_major_minor() {
+  local version="$1"
+  if [[ "${version}" =~ ^([0-9]+\.[0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
     return 0
   fi
   return 1
 }
 
-# Best-effort match: target satisfies the caret range of an older source line.
-# Example: 1.49.3 is compatible with target 1.52.0.
-backstage_versions_best_effort_match() {
-  local source="$1"
-  local target="$2"
-  if [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]; then
-    return 0
-  fi
-  return 1
-}
-
-# Combined check used by publish/compatibility validation.
+# True when source and target share the same major.minor line.
 backstage_versions_compatible() {
   local source="$1"
   local target="$2"
-  if backstage_versions_exact_match "${source}" "${target}" ||
-    backstage_versions_best_effort_match "${source}" "${target}"; then
+  local source_mm target_mm
+  source_mm="$(backstage_major_minor "${source}")" || return 1
+  target_mm="$(backstage_major_minor "${target}")" || return 1
+  if [[ "${source_mm}" == "${target_mm}" ]]; then
     return 0
   fi
   return 1

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -2,7 +2,7 @@
 
 # Shared Backstage version compatibility helpers for overlay automation workflows.
 #
-# Exact match: same major.minor line (patch ignored in either direction).
+# Exact minor match: same major.minor line (patch .z treated as equivalent).
 #   Example: source 1.52.1 matches target 1.52.0.
 #
 # Best-effort match: target is a newer minor/patch on the same major line

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -12,26 +12,13 @@
 #
 # Usage:
 #   source common/scripts/backstage-version-compatible.sh
-#   backstage_versions_exact_match "1.52.1" "1.52.0" && echo exact
+#   backstage_versions_minor_match "1.52.1" "1.52.0" && echo minor
 
-# Extract major.minor from a semver-like string (x.y or x.y.z).
-backstage_major_minor() {
-  local version="$1"
-  if [[ "${version}" =~ ^([0-9]+\.[0-9]+) ]]; then
-    echo "${BASH_REMATCH[1]}"
-    return 0
-  fi
-  return 1
-}
-
-# Exact match: same major.minor line, regardless of patch direction.
-backstage_versions_exact_match() {
+# Same major.minor line (versions are always x.y.z; strip the patch with %.*).
+backstage_versions_minor_match() {
   local source="$1"
   local target="$2"
-  local source_mm target_mm
-  source_mm="$(backstage_major_minor "${source}")" || return 1
-  target_mm="$(backstage_major_minor "${target}")" || return 1
-  if [[ "${source_mm}" == "${target_mm}" ]]; then
+  if [[ "${source%.*}" == "${target%.*}" ]]; then
     return 0
   fi
   return 1
@@ -42,8 +29,8 @@ backstage_versions_exact_match() {
 backstage_versions_best_effort_match() {
   local source="$1"
   local target="$2"
-  # Same major.minor is exact, not best-effort.
-  if backstage_versions_exact_match "${source}" "${target}"; then
+  # Same major.minor is a minor match, not best-effort.
+  if backstage_versions_minor_match "${source}" "${target}"; then
     return 1
   fi
   if [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]; then
@@ -52,11 +39,11 @@ backstage_versions_best_effort_match() {
   return 1
 }
 
-# Either exact or best-effort (for callers that only need a yes/no).
+# Either minor or best-effort (for callers that only need a yes/no).
 backstage_versions_compatible() {
   local source="$1"
   local target="$2"
-  if backstage_versions_exact_match "${source}" "${target}" ||
+  if backstage_versions_minor_match "${source}" "${target}" ||
     backstage_versions_best_effort_match "${source}" "${target}"; then
     return 0
   fi

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Shared Backstage version compatibility helpers for overlay automation workflows.
+#
+# Usage:
+#   source common/scripts/backstage-version-compatible.sh
+#   backstage_versions_exact_match "1.52.1" "1.52.0" && echo exact
+
+# Exact match: same major.minor line, regardless of patch direction.
+# Example: 1.52.1 is compatible with target 1.52.0.
+backstage_versions_exact_match() {
+  local source="$1"
+  local target="$2"
+  [[ "${target}" == "$(semver -r "~${source}" "${target}")" ]] ||
+    [[ "${source}" == "$(semver -r "~${target}" "${source}")" ]]
+}
+
+# Best-effort match: target satisfies the caret range of an older source line.
+# Example: 1.49.3 is compatible with target 1.52.0.
+backstage_versions_best_effort_match() {
+  local source="$1"
+  local target="$2"
+  [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]
+}
+
+# Combined check used by publish/compatibility validation.
+backstage_versions_compatible() {
+  local source="$1"
+  local target="$2"
+  backstage_versions_exact_match "${source}" "${target}" ||
+    backstage_versions_best_effort_match "${source}" "${target}"
+}

--- a/common/scripts/backstage-version-compatible.sh
+++ b/common/scripts/backstage-version-compatible.sh
@@ -2,13 +2,17 @@
 
 # Shared Backstage version compatibility helpers for overlay automation workflows.
 #
-# Compatibility means the same major.minor line (e.g. 1.52.*). Patch suffixes
-# are ignored in either direction — 1.52.1 matches target 1.52.0 and vice versa.
-# Different minors are not treated as compatible (1.49.x does not match 1.52.x).
+# Exact match: same major.minor line (patch ignored in either direction).
+#   Example: source 1.52.1 matches target 1.52.0.
+#
+# Best-effort match: target is a newer minor/patch on the same major line
+#   (semver caret). Used by discovery to open review/test PRs for older plugins
+#   that may still run on a newer Backstage; smoke/e2e gates verify them.
+#   Example: source 1.49.3 matches target 1.52.0.
 #
 # Usage:
 #   source common/scripts/backstage-version-compatible.sh
-#   backstage_versions_compatible "1.52.1" "1.52.0" && echo compatible
+#   backstage_versions_exact_match "1.52.1" "1.52.0" && echo exact
 
 # Extract major.minor from a semver-like string (x.y or x.y.z).
 backstage_major_minor() {
@@ -20,14 +24,40 @@ backstage_major_minor() {
   return 1
 }
 
-# True when source and target share the same major.minor line.
-backstage_versions_compatible() {
+# Exact match: same major.minor line, regardless of patch direction.
+backstage_versions_exact_match() {
   local source="$1"
   local target="$2"
   local source_mm target_mm
   source_mm="$(backstage_major_minor "${source}")" || return 1
   target_mm="$(backstage_major_minor "${target}")" || return 1
   if [[ "${source_mm}" == "${target_mm}" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Best-effort match: target satisfies the caret range of an older source line.
+# Requires semver CLI. Does not match when source is newer than target.
+backstage_versions_best_effort_match() {
+  local source="$1"
+  local target="$2"
+  # Same major.minor is exact, not best-effort.
+  if backstage_versions_exact_match "${source}" "${target}"; then
+    return 1
+  fi
+  if [[ "${target}" == "$(semver -r "^${source}" "${target}")" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Either exact or best-effort (for callers that only need a yes/no).
+backstage_versions_compatible() {
+  local source="$1"
+  local target="$2"
+  if backstage_versions_exact_match "${source}" "${target}" ||
+    backstage_versions_best_effort_match "${source}" "${target}"; then
     return 0
   fi
   return 1

--- a/common/scripts/backstage-version-compatible.test.sh
+++ b/common/scripts/backstage-version-compatible.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v semver >/dev/null 2>&1; then
+  npm install -g semver >/dev/null 2>&1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common/scripts/backstage-version-compatible.sh
+source "${SCRIPT_DIR}/backstage-version-compatible.sh"
+
+assert_true() {
+  local description="$1"
+  shift
+  if "$@"; then
+    echo "PASS: ${description}"
+  else
+    echo "FAIL: ${description}" >&2
+    exit 1
+  fi
+}
+
+assert_false() {
+  local description="$1"
+  shift
+  if "$@"; then
+    echo "FAIL: ${description}" >&2
+    exit 1
+  else
+    echo "PASS: ${description}"
+  fi
+}
+
+assert_true "1.52.0 exact matches 1.52.0" backstage_versions_exact_match "1.52.0" "1.52.0"
+assert_true "1.52.1 exact matches 1.52.0" backstage_versions_exact_match "1.52.1" "1.52.0"
+assert_true "1.52.0 exact matches 1.52.1" backstage_versions_exact_match "1.52.0" "1.52.1"
+assert_false "1.49.3 is not an exact match for 1.52.0" backstage_versions_exact_match "1.49.3" "1.52.0"
+assert_false "1.53.0 is not an exact match for 1.52.0" backstage_versions_exact_match "1.53.0" "1.52.0"
+
+assert_true "1.49.3 best-effort matches 1.52.0" backstage_versions_best_effort_match "1.49.3" "1.52.0"
+assert_false "1.52.1 best-effort does not replace exact semantics" backstage_versions_best_effort_match "1.52.1" "1.52.0"
+
+assert_true "1.52.1 is compatible with 1.52.0" backstage_versions_compatible "1.52.1" "1.52.0"
+assert_true "1.49.3 is compatible with 1.52.0" backstage_versions_compatible "1.49.3" "1.52.0"
+assert_false "1.53.0 is not compatible with 1.52.0" backstage_versions_compatible "1.53.0" "1.52.0"
+
+echo "All backstage version compatibility tests passed."

--- a/common/scripts/backstage-version-compatible.test.sh
+++ b/common/scripts/backstage-version-compatible.test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v semver >/dev/null 2>&1; then
+  npm install -g semver >/dev/null 2>&1
+fi
+
 readonly BS_1_52_0="1.52.0"
 readonly BS_1_52_1="1.52.1"
 readonly BS_1_49_3="1.49.3"
@@ -32,10 +36,21 @@ assert_false() {
   fi
 }
 
-assert_true "${BS_1_52_0} compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_0}" "${BS_1_52_0}"
+# Exact: same major.minor, patch ignored either way
+assert_true "${BS_1_52_0} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_0}"
+assert_true "${BS_1_52_1} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_1}" "${BS_1_52_0}"
+assert_true "${BS_1_52_0} exact matches ${BS_1_52_1}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_1}"
+assert_false "${BS_1_49_3} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_53_0}" "${BS_1_52_0}"
+
+# Best-effort: older minor against newer target (gated by smoke/e2e)
+assert_true "${BS_1_49_3} best-effort matches ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_52_1} is exact not best-effort vs ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_52_1}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} best-effort does not match older ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_53_0}" "${BS_1_52_0}"
+
+# Combined
 assert_true "${BS_1_52_1} compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_1}" "${BS_1_52_0}"
-assert_true "${BS_1_52_0} compatible with ${BS_1_52_1}" backstage_versions_compatible "${BS_1_52_0}" "${BS_1_52_1}"
-assert_false "${BS_1_49_3} not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_49_3}" "${BS_1_52_0}"
+assert_true "${BS_1_49_3} compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_49_3}" "${BS_1_52_0}"
 assert_false "${BS_1_53_0} not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_53_0}" "${BS_1_52_0}"
 
 echo "All backstage version compatibility tests passed."

--- a/common/scripts/backstage-version-compatible.test.sh
+++ b/common/scripts/backstage-version-compatible.test.sh
@@ -5,6 +5,11 @@ if ! command -v semver >/dev/null 2>&1; then
   npm install -g semver >/dev/null 2>&1
 fi
 
+readonly BS_1_52_0="1.52.0"
+readonly BS_1_52_1="1.52.1"
+readonly BS_1_49_3="1.49.3"
+readonly BS_1_53_0="1.53.0"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common/scripts/backstage-version-compatible.sh
 source "${SCRIPT_DIR}/backstage-version-compatible.sh"
@@ -31,17 +36,17 @@ assert_false() {
   fi
 }
 
-assert_true "1.52.0 exact matches 1.52.0" backstage_versions_exact_match "1.52.0" "1.52.0"
-assert_true "1.52.1 exact matches 1.52.0" backstage_versions_exact_match "1.52.1" "1.52.0"
-assert_true "1.52.0 exact matches 1.52.1" backstage_versions_exact_match "1.52.0" "1.52.1"
-assert_false "1.49.3 is not an exact match for 1.52.0" backstage_versions_exact_match "1.49.3" "1.52.0"
-assert_false "1.53.0 is not an exact match for 1.52.0" backstage_versions_exact_match "1.53.0" "1.52.0"
+assert_true "${BS_1_52_0} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_0}"
+assert_true "${BS_1_52_1} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_1}" "${BS_1_52_0}"
+assert_true "${BS_1_52_0} exact matches ${BS_1_52_1}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_1}"
+assert_false "${BS_1_49_3} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_53_0}" "${BS_1_52_0}"
 
-assert_true "1.49.3 best-effort matches 1.52.0" backstage_versions_best_effort_match "1.49.3" "1.52.0"
-assert_false "1.52.1 best-effort does not replace exact semantics" backstage_versions_best_effort_match "1.52.1" "1.52.0"
+assert_true "${BS_1_49_3} best-effort matches ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_52_1} best-effort does not replace exact semantics" backstage_versions_best_effort_match "${BS_1_52_1}" "${BS_1_52_0}"
 
-assert_true "1.52.1 is compatible with 1.52.0" backstage_versions_compatible "1.52.1" "1.52.0"
-assert_true "1.49.3 is compatible with 1.52.0" backstage_versions_compatible "1.49.3" "1.52.0"
-assert_false "1.53.0 is not compatible with 1.52.0" backstage_versions_compatible "1.53.0" "1.52.0"
+assert_true "${BS_1_52_1} is compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_1}" "${BS_1_52_0}"
+assert_true "${BS_1_49_3} is compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} is not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_53_0}" "${BS_1_52_0}"
 
 echo "All backstage version compatibility tests passed."

--- a/common/scripts/backstage-version-compatible.test.sh
+++ b/common/scripts/backstage-version-compatible.test.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v semver >/dev/null 2>&1; then
-  npm install -g semver >/dev/null 2>&1
-fi
-
 readonly BS_1_52_0="1.52.0"
 readonly BS_1_52_1="1.52.1"
 readonly BS_1_49_3="1.49.3"
@@ -36,17 +32,10 @@ assert_false() {
   fi
 }
 
-assert_true "${BS_1_52_0} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_0}"
-assert_true "${BS_1_52_1} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_1}" "${BS_1_52_0}"
-assert_true "${BS_1_52_0} exact matches ${BS_1_52_1}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_1}"
-assert_false "${BS_1_49_3} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_49_3}" "${BS_1_52_0}"
-assert_false "${BS_1_53_0} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_53_0}" "${BS_1_52_0}"
-
-assert_true "${BS_1_49_3} best-effort matches ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_49_3}" "${BS_1_52_0}"
-assert_false "${BS_1_52_1} best-effort does not replace exact semantics" backstage_versions_best_effort_match "${BS_1_52_1}" "${BS_1_52_0}"
-
-assert_true "${BS_1_52_1} is compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_1}" "${BS_1_52_0}"
-assert_true "${BS_1_49_3} is compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_49_3}" "${BS_1_52_0}"
-assert_false "${BS_1_53_0} is not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_53_0}" "${BS_1_52_0}"
+assert_true "${BS_1_52_0} compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_0}" "${BS_1_52_0}"
+assert_true "${BS_1_52_1} compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_52_1}" "${BS_1_52_0}"
+assert_true "${BS_1_52_0} compatible with ${BS_1_52_1}" backstage_versions_compatible "${BS_1_52_0}" "${BS_1_52_1}"
+assert_false "${BS_1_49_3} not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} not compatible with ${BS_1_52_0}" backstage_versions_compatible "${BS_1_53_0}" "${BS_1_52_0}"
 
 echo "All backstage version compatibility tests passed."

--- a/common/scripts/backstage-version-compatible.test.sh
+++ b/common/scripts/backstage-version-compatible.test.sh
@@ -36,16 +36,16 @@ assert_false() {
   fi
 }
 
-# Exact: same major.minor, patch ignored either way
-assert_true "${BS_1_52_0} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_0}"
-assert_true "${BS_1_52_1} exact matches ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_52_1}" "${BS_1_52_0}"
-assert_true "${BS_1_52_0} exact matches ${BS_1_52_1}" backstage_versions_exact_match "${BS_1_52_0}" "${BS_1_52_1}"
-assert_false "${BS_1_49_3} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_49_3}" "${BS_1_52_0}"
-assert_false "${BS_1_53_0} is not an exact match for ${BS_1_52_0}" backstage_versions_exact_match "${BS_1_53_0}" "${BS_1_52_0}"
+# Minor match: same major.minor, patch ignored either way
+assert_true "${BS_1_52_0} minor matches ${BS_1_52_0}" backstage_versions_minor_match "${BS_1_52_0}" "${BS_1_52_0}"
+assert_true "${BS_1_52_1} minor matches ${BS_1_52_0}" backstage_versions_minor_match "${BS_1_52_1}" "${BS_1_52_0}"
+assert_true "${BS_1_52_0} minor matches ${BS_1_52_1}" backstage_versions_minor_match "${BS_1_52_0}" "${BS_1_52_1}"
+assert_false "${BS_1_49_3} is not a minor match for ${BS_1_52_0}" backstage_versions_minor_match "${BS_1_49_3}" "${BS_1_52_0}"
+assert_false "${BS_1_53_0} is not a minor match for ${BS_1_52_0}" backstage_versions_minor_match "${BS_1_53_0}" "${BS_1_52_0}"
 
 # Best-effort: older minor against newer target (gated by smoke/e2e)
 assert_true "${BS_1_49_3} best-effort matches ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_49_3}" "${BS_1_52_0}"
-assert_false "${BS_1_52_1} is exact not best-effort vs ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_52_1}" "${BS_1_52_0}"
+assert_false "${BS_1_52_1} is minor not best-effort vs ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_52_1}" "${BS_1_52_0}"
 assert_false "${BS_1_53_0} best-effort does not match older ${BS_1_52_0}" backstage_versions_best_effort_match "${BS_1_53_0}" "${BS_1_52_0}"
 
 # Combined


### PR DESCRIPTION
## Summary

- Add shared `backstage-version-compatible.sh` helpers that treat same major.minor Backstage lines as exact matches in either patch direction (e.g. source `1.52.1` with overlay target `1.52.0`).
- Update plugin discovery, compatibility checks, and OCI tag prefix selection to use the shared helpers.
- Add shell tests covering exact, best-effort, and incompatible version pairs.

Fixes [RHDHBUGS-3477](https://redhat.atlassian.net/browse/RHDHBUGS-3477).

This resolves the app-defaults case where `a04cf01` (Backstage `1.52.1`) was skipped in favor of `3c91057` (Backstage `1.49.3`) while overlay `main` still targets `1.52.0`.

## Test plan

- [x] `bash common/scripts/backstage-version-compatible.test.sh`
- [ ] Merge export-utils PR
- [ ] On overlay PR #2783, comment `/update-commit` and verify it moves to `a04cf01` with plugin versions `0.1.0`
- [ ] `/publish` and confirm `bs_1.52.0__0.1.0` tags and no incompatible-workspace warning for app-defaults
- [ ] Re-run app-defaults e2e on overlay PR #2783


Made with [Cursor](https://cursor.com)