### PR TITLE
feat(validate-metadata): expose coverage warnings as outputs and a per-workspace artifact

### DIFF
--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -465,3 +465,34 @@ jobs:
           target-backstage-version: ${{ inputs.target-backstage-version }}
           image-repository-prefix: ${{ steps.set-image-tag-name.outputs.IMAGE_REPOSITORY_PREFIX }}
           computed-image-tag-prefix: ${{ inputs.computed-image-tag-prefix }}
+
+      # The coverage warnings (plugins exported by plugins-list.yaml with no
+      # matching metadata file) are computed above with the source repo present —
+      # the only place the path-to-packageName join can happen. Published as an
+      # artifact so downstream verification (the Drydock gate) can grade the
+      # absence without a source checkout of its own.
+      - name: Publish metadata coverage warnings
+        if: ${{ always() && steps.validate-metadata.outcome != 'skipped' }}
+        env:
+          INPUT_OVERLAY_ROOT: ${{ inputs.overlay-root }}
+          METADATA_WARNINGS: ${{ steps.validate-metadata.outputs.metadata-warning-packages }}
+        run: |
+          mkdir -p "${{ github.workspace }}/metadata-warnings"
+          node -e '
+            const fs = require("fs");
+            const warnings = JSON.parse(process.env.METADATA_WARNINGS || "[]");
+            const workspace = process.env.INPUT_OVERLAY_ROOT || ".";
+            const file = process.env.GITHUB_WORKSPACE + "/metadata-warnings/metadata-warnings.json";
+            fs.writeFileSync(file, JSON.stringify({ workspace, warnings }, null, 2) + "\n");
+            console.log(`${warnings.length} coverage warning(s) for ${workspace}`);
+          '
+
+      - name: Upload metadata coverage warnings
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ always() && steps.validate-metadata.outcome != 'skipped' }}
+        with:
+          name: metadata warnings${{ steps.set-artifacts-name-suffix.outputs.ARTIFACTS_NAME_SUFFIX }}
+          path: ${{ github.workspace }}/metadata-warnings
+          if-no-files-found: warn
+          retention-days: ${{ inputs.artifact-retention-days }}
+          overwrite: true

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -118,6 +118,12 @@ on:
         description: Optional commit ID of the last successful publishing of plugin container images
         type: string
         required: false
+
+      bundle-workspace:
+        description: Bundle all exported plugins into a single OCI image per workspace instead of one image per plugin
+        type: boolean
+        default: false
+        required: false
             
     outputs:
       published-exports:
@@ -303,6 +309,7 @@ jobs:
           image-repository-prefix: ${{ steps.set-image-tag-name.outputs.IMAGE_REPOSITORY_PREFIX }}
           image-tag-prefix: ${{ inputs.image-tag-prefix }}
           last-publish-commit: ${{ inputs.last-publish-commit }}
+          bundle-workspace: ${{ inputs.bundle-workspace }}
 
       - name: Set artifacts name suffix
         id: set-artifacts-name-suffix

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -5,6 +5,9 @@ on:
       image-registry-password:
         description: Password to be used to push to container image registry
         required: false
+      quay-api-token:
+        description: Quay.io OAuth token for API operations (setting repo visibility to public)
+        required: false
   
     inputs:
       image-registry-user:
@@ -364,6 +367,35 @@ jobs:
               .addHeading(`Published container images for workspace '${overlayRoot}' :`, 4)
               .addList(publishedExports)
               .write();
+
+      - name: Set Quay.io repository visibility to public
+        if: ${{ success() && steps.export-dynamic.outputs.published-exports != '' && secrets.quay-api-token != '' }}
+        env:
+          PUBLISHED_EXPORTS: ${{ steps.export-dynamic.outputs.published-exports }}
+          QUAY_API_TOKEN: ${{ secrets.quay-api-token }}
+        run: |
+          echo "$PUBLISHED_EXPORTS" | while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            # Extract registry/namespace/repo from image reference (e.g. quay.io/veecode/argocd:tag)
+            registry=$(echo "$image" | cut -d/ -f1)
+            if [[ "$registry" != "quay.io" ]]; then
+              echo "  Skipping non-Quay image: $image"
+              continue
+            fi
+            namespace=$(echo "$image" | cut -d/ -f2)
+            repo=$(echo "$image" | cut -d/ -f3 | cut -d: -f1)
+            echo -n "  Setting $namespace/$repo to public... "
+            status=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+              -H "Authorization: Bearer ${QUAY_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"visibility":"public"}' \
+              "https://quay.io/api/v1/repository/${namespace}/${repo}/changevisibility")
+            if [[ "$status" == "200" ]]; then
+              echo "OK"
+            else
+              echo "FAILED (HTTP $status)"
+            fi
+          done
 
       - name: Log that the workspace has been skipped
         if: ${{ success() && steps.export-dynamic.outputs.workspace-skipped-unchanged-since != 'false' }}

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -202,7 +202,7 @@ jobs:
           fetch-depth: 50
 
       - name: Override Sources
-        uses: redhat-developer/rhdh-plugin-export-utils/override-sources@main
+        uses: veecode-platform/devportal-plugin-export-utils/override-sources@main
         with:
           overlay-root: ${{ github.workspace }}/overlay-repo/${{inputs.overlay-root}}
           workspace-root: source-repo/${{ inputs.plugins-root }}
@@ -293,7 +293,7 @@ jobs:
       - name: Export dynamic plugin packages
         if: ${{ success() }}
         id: export-dynamic
-        uses: redhat-developer/rhdh-plugin-export-utils/export-dynamic@main
+        uses: veecode-platform/devportal-plugin-export-utils/export-dynamic@main
         with:
           plugins-root: source-repo/${{inputs.plugins-root}}
           plugins-file: ${{ github.workspace }}/overlay-repo/${{inputs.overlay-root}}/plugins-list.yaml
@@ -403,7 +403,7 @@ jobs:
       - name: Validate Catalog Metadata
         if: ${{ failure() || steps.export-dynamic.outputs.workspace-skipped-unchanged-since == 'false' }}
         id: validate-metadata
-        uses: redhat-developer/rhdh-plugin-export-utils/validate-metadata@main
+        uses: veecode-platform/devportal-plugin-export-utils/validate-metadata@main
         with:
           overlay-root: ${{ github.workspace }}/overlay-repo/${{inputs.overlay-root}}
           plugins-root: ${{ github.workspace }}/source-repo/${{inputs.plugins-root}}

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -389,7 +389,7 @@ jobs:
             namespace=$(echo "$image" | cut -d/ -f2)
             repo=$(echo "$image" | cut -d/ -f3 | cut -d: -f1)
             echo -n "  Setting $namespace/$repo to public... "
-            status=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+            status=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
               -H "Authorization: Bearer ${QUAY_API_TOKEN}" \
               -H "Content-Type: application/json" \
               -d '{"visibility":"public"}' \

--- a/.github/workflows/export-dynamic.yaml
+++ b/.github/workflows/export-dynamic.yaml
@@ -369,11 +369,15 @@ jobs:
               .write();
 
       - name: Set Quay.io repository visibility to public
-        if: ${{ success() && steps.export-dynamic.outputs.published-exports != '' && secrets.quay-api-token != '' }}
+        if: ${{ success() && steps.export-dynamic.outputs.published-exports != '' }}
         env:
           PUBLISHED_EXPORTS: ${{ steps.export-dynamic.outputs.published-exports }}
           QUAY_API_TOKEN: ${{ secrets.quay-api-token }}
         run: |
+          if [[ -z "$QUAY_API_TOKEN" ]]; then
+            echo "QUAY_API_TOKEN not set, skipping visibility change"
+            exit 0
+          fi
           echo "$PUBLISHED_EXPORTS" | while IFS= read -r image; do
             [ -z "$image" ] && continue
             # Extract registry/namespace/repo from image reference (e.g. quay.io/veecode/argocd:tag)

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -227,7 +227,7 @@ jobs:
   export:
     name: Export ${{ matrix.workspace.overlay-root }}
     needs: prepare
-    uses: redhat-developer/rhdh-plugin-export-utils/.github/workflows/export-dynamic.yaml@main
+    uses: veecode-platform/devportal-plugin-export-utils/.github/workflows/export-dynamic.yaml@main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -74,6 +74,12 @@ on:
         type: string
         required: false
 
+      bundle-workspace:
+        description: Bundle all exported plugins into a single OCI image per workspace instead of one image per plugin
+        type: boolean
+        default: false
+        required: false
+
     outputs:
       published-exports:
         value: '${{ jobs.export.outputs.published-exports }}'
@@ -250,6 +256,7 @@ jobs:
       image-tag-prefix: ${{ inputs.image-tag-prefix != '' && inputs.image-tag-prefix || format('bs_{0}__', needs.prepare.outputs.backstage-version) }}
       target-backstage-version: ${{ needs.prepare.outputs.backstage-version }}
       last-publish-commit: ${{ inputs.last-publish-commit }}
+      bundle-workspace: ${{ inputs.bundle-workspace }}
       image-registry-user: ${{ inputs.image-registry-user }}
 
     secrets:

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -5,6 +5,9 @@ on:
       image-registry-password:
         description: Password to be used to push to container image registry
         required: false
+      quay-api-token:
+        description: Quay.io OAuth token for API operations (setting repo visibility to public)
+        required: false
     
     inputs:
       image-registry-user:
@@ -261,6 +264,7 @@ jobs:
 
     secrets:
       image-registry-password: ${{ secrets.image-registry-password }}
+      quay-api-token: ${{ secrets.quay-api-token }}
 
     permissions:
       contents: write

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -83,6 +83,18 @@ on:
         default: false
         required: false
 
+      rc-tag-suffix:
+        description: >-
+          Optional release-candidate suffix appended to the computed backstage tag,
+          e.g. '-rc.abc1234' produces bs_1.53.0-rc.abc1234__ instead of bs_1.53.0__.
+          Applied ONLY where the compatibility check already selected the bs_ prefix,
+          so workspaces that fall back to next__ keep doing so — an incompatible
+          workspace must never carry a tag asserting a version it does not support.
+          Ignored when image-tag-prefix is set, which overrides the computation wholesale.
+        type: string
+        default: ''
+        required: false
+
     outputs:
       published-exports:
         value: '${{ jobs.export.outputs.published-exports }}'
@@ -191,6 +203,7 @@ jobs:
           OVERLAY_REPO: ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
           OVERLAY_REPO_REF: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
           TARGET_BACKSTAGE_VERSION: ${{ steps.set-env-vars.outputs.BACKSTAGE_VERSION }}
+          RC_TAG_SUFFIX: ${{ inputs.rc-tag-suffix }}
         run: |
           if [[ "${OVERLAY_REPO}" != "${{ github.repository }}" ]]; then
             echo "Exporting overlay workspaces from branch \`${OVERLAY_REPO_REF}\` of repository \`${OVERLAY_REPO}\`"
@@ -236,7 +249,7 @@ jobs:
                 if [[ "${workspaceBackstageVersion}" != "" ]] && \
                    [[ "${TARGET_BACKSTAGE_VERSION}" == "$(semver -r "~${workspaceBackstageVersion}" "${TARGET_BACKSTAGE_VERSION}")" ]]
                 then
-                  wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}__"
+                  wsTagPrefix="bs_${TARGET_BACKSTAGE_VERSION}${RC_TAG_SUFFIX}__"
                 fi
 
                 workspace=$(echo "${workspace}" | jq -c ". += {\"computed-image-tag-prefix\": \"${wsTagPrefix}\"}")

--- a/.github/workflows/test-validate-metadata.yaml
+++ b/.github/workflows/test-validate-metadata.yaml
@@ -103,18 +103,18 @@ jobs:
             kind: 'mismatch',
             file: 'test-fail.yaml',
             field: 'dynamicArtifact.tag',
-            expected: 'bs_1.42.5__1.0.0',
+            expected: 'bs_1.42.5__1.0.0 or bs_1.42.5',
             actual: 'wrong_tag_1.0.0',
-            message: 'OCI tag mismatch: expected "bs_1.42.5__1.0.0" but got "wrong_tag_1.0.0"'
+            message: 'OCI tag mismatch: expected "bs_1.42.5__1.0.0" or "bs_1.42.5" but got "wrong_tag_1.0.0"'
           });
 
           assertError('dynamicArtifact.reference', {
             kind: 'mismatch',
             file: 'test-fail.yaml',
             field: 'dynamicArtifact.reference',
-            expected: 'oci://ghcr.io/test-org/test-repo/test-org-plugin-test',
+            expected: 'oci://ghcr.io/test-org/test-repo/test-org-plugin-test or oci://ghcr.io/test-org/test-repo/fail',
             actual: 'oci://ghcr.io/wrong-org/wrong-repo/wrong-image',
-            message: 'OCI reference mismatch: expected "oci://ghcr.io/test-org/test-repo/test-org-plugin-test" but got "oci://ghcr.io/wrong-org/wrong-repo/wrong-image"'
+            message: 'OCI reference mismatch: expected "oci://ghcr.io/test-org/test-repo/test-org-plugin-test" or "oci://ghcr.io/test-org/test-repo/fail" but got "oci://ghcr.io/wrong-org/wrong-repo/wrong-image"'
           });
 
           assertError('backstage.supportedVersions', {

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -576,7 +576,7 @@ jobs:
 
       - name: Create PR if necessary
         id: create-pr-if-necessary
-        uses: redhat-developer/rhdh-plugin-export-utils/update-overlay@main
+        uses: veecode-platform/devportal-plugin-export-utils/update-overlay@main
         with:
           overlay-repo: ${{ inputs.overlay-repo }}
           overlay-repo-branch-name: ${{ steps.prepare.outputs.overlay-repo-branch-name }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# rhdh-plugin-export-utils
-Utilities for exporting backstage plugins as dynamic plugins for installation in Red Hat Developer Hub
+# devportal-plugin-export-utils
+Utilities for exporting backstage plugins as dynamic plugins for installation in DevPortal
 
 ## Actions
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Validates catalog metadata files against plugin `package.json` files to ensure c
     overlay-root: ${{ github.workspace }}/overlay-repo/workspaces/my-workspace
     plugins-root: ${{ github.workspace }}/source-repo/workspaces/my-workspace
     target-backstage-version: 1.42.5
-    image-repository-prefix: ghcr.io/my-org/my-repo  # Optional
+    image-repository-prefix: quay.io/veecode  # Optional
 ```
 
 **Inputs:**

--- a/export-dynamic/action.yaml
+++ b/export-dynamic/action.yaml
@@ -64,6 +64,11 @@ inputs:
     default: ""
     required: false
 
+  bundle-workspace:
+    description: Bundle all exported plugins into a single OCI image per workspace instead of one image per plugin
+    default: "false"
+    required: false
+
 outputs:
   failed-exports:
     description: "Failed exports"
@@ -108,5 +113,6 @@ runs:
         INPUTS_IMAGE_TAG_PREFIX: "${{ inputs.image-tag-prefix }}"
         INPUTS_PUSH_CONTAINER_IMAGE: "true"
         INPUTS_LAST_PUBLISH_COMMIT: "${{ inputs.last-publish-commit }}"
+        INPUTS_BUNDLE_WORKSPACE: "${{ inputs.bundle-workspace }}"
       # for now always pass this step so we can get all the followup logging steps to still run even if the export fails
       run: ${{ github.action_path }}/export-dynamic.sh || true

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -236,7 +236,7 @@ else
         cat "$CONTAINERFILE"
         echo ""
 
-        if ${INPUTS_CONTAINER_BUILD_TOOL} build -f "$CONTAINERFILE" -t "${WORKSPACE_IMAGE}" .; then
+        if ${INPUTS_CONTAINER_BUILD_TOOL} build --ignorefile /dev/null -f "$CONTAINERFILE" -t "${WORKSPACE_IMAGE}" .; then
             if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]
             then
                 echo "========== Publishing Workspace Bundle ${WORKSPACE_IMAGE} =========="

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -236,7 +236,13 @@ else
         cat "$CONTAINERFILE"
         echo ""
 
-        if ${INPUTS_CONTAINER_BUILD_TOOL} build --ignorefile /dev/null -f "$CONTAINERFILE" -t "${WORKSPACE_IMAGE}" .; then
+        # Temporarily remove .dockerignore/.containerignore to prevent filtering of COPY sources
+        # (some upstream workspaces exclude 'plugins/' which contains our dist-dynamic dirs)
+        for ign in .dockerignore .containerignore; do
+            if [ -f "$ign" ]; then mv "$ign" "${ign}.bundle-bak"; fi
+        done
+
+        if ${INPUTS_CONTAINER_BUILD_TOOL} build -f "$CONTAINERFILE" -t "${WORKSPACE_IMAGE}" .; then
             if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]
             then
                 echo "========== Publishing Workspace Bundle ${WORKSPACE_IMAGE} =========="
@@ -253,6 +259,11 @@ else
             echo " Error building workspace bundle image"
             errors+=("workspace-bundle:${WORKSPACE_NAME}")
         fi
+
+        # Restore ignore files
+        for ign in .dockerignore .containerignore; do
+            if [ -f "${ign}.bundle-bak" ]; then mv "${ign}.bundle-bak" "$ign"; fi
+        done
 
         rm -f "$CONTAINERFILE"
     fi

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -2,6 +2,7 @@
 
 errors=()
 images=()
+exported_plugins=()  # tracks "pluginPath:pluginName" for workspace bundling
 IFS=$'\n'
 
 workspaceOverlayFolder="$(dirname "${INPUTS_PLUGINS_FILE}")"
@@ -144,26 +145,34 @@ else
         if [[ "${INPUTS_IMAGE_REPOSITORY_PREFIX}" != "" ]]
         then
             PLUGIN_NAME=$(jq -r '.name | sub("^@"; "") | sub("[/@]"; "-")' package.json)
-            PLUGIN_VERSION="${INPUTS_IMAGE_TAG_PREFIX}$(jq -r '.version' package.json)"
-            PLUGIN_CONTAINER_TAG="${INPUTS_IMAGE_REPOSITORY_PREFIX}/${PLUGIN_NAME}:${PLUGIN_VERSION}"
 
-            echo "========== Packaging Container ${PLUGIN_CONTAINER_TAG} =========="
-            if run_cli "${PACKAGE_COMMAND[@]}" --tag "${PLUGIN_CONTAINER_TAG}"; then
-                if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]
-                then
-                    echo "========== Publishing Container ${PLUGIN_CONTAINER_TAG} =========="
-                    if ${INPUTS_CONTAINER_BUILD_TOOL} push "$PLUGIN_CONTAINER_TAG"; then
-                        images+=("${PLUGIN_CONTAINER_TAG}")
+            if [[ "${INPUTS_BUNDLE_WORKSPACE}" == "true" ]]
+            then
+                # workspace bundling: just track the plugin for post-loop Containerfile build
+                exported_plugins+=("${pluginPath}:${PLUGIN_NAME}")
+                echo "  Queued for workspace bundle: ${PLUGIN_NAME}"
+            else
+                PLUGIN_VERSION="${INPUTS_IMAGE_TAG_PREFIX}$(jq -r '.version' package.json)"
+                PLUGIN_CONTAINER_TAG="${INPUTS_IMAGE_REPOSITORY_PREFIX}/${PLUGIN_NAME}:${PLUGIN_VERSION}"
+
+                echo "========== Packaging Container ${PLUGIN_CONTAINER_TAG} =========="
+                if run_cli "${PACKAGE_COMMAND[@]}" --tag "${PLUGIN_CONTAINER_TAG}"; then
+                    if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]
+                    then
+                        echo "========== Publishing Container ${PLUGIN_CONTAINER_TAG} =========="
+                        if ${INPUTS_CONTAINER_BUILD_TOOL} push "$PLUGIN_CONTAINER_TAG"; then
+                            images+=("${PLUGIN_CONTAINER_TAG}")
+                        else
+                            echo " Error pushing container image"
+                            errors+=("${pluginPath}")
+                        fi
                     else
-                        echo " Error pushing container image"
-                        errors+=("${pluginPath}")
+                            images+=("${PLUGIN_CONTAINER_TAG}")
                     fi
                 else
-                        images+=("${PLUGIN_CONTAINER_TAG}")
+                    echo " Error building container image"
+                    errors+=("${pluginPath}")
                 fi
-            else
-                echo " Error building container image"
-                errors+=("${pluginPath}")
             fi
         fi
         echo
@@ -197,6 +206,57 @@ else
         set -e
         popd > /dev/null
     done < "${INPUTS_PLUGINS_FILE}"
+
+    # Build workspace bundle image (all exported plugins in a single OCI image with 1 layer)
+    if [[ "${INPUTS_BUNDLE_WORKSPACE}" == "true" ]] && [[ "${INPUTS_IMAGE_REPOSITORY_PREFIX}" != "" ]] && [[ ${#exported_plugins[@]} -gt 0 ]]
+    then
+        WORKSPACE_NAME=$(basename "${workspaceOverlayFolder}")
+        # Strip trailing __ from tag prefix to get workspace-level tag (no per-plugin version)
+        WORKSPACE_TAG="${INPUTS_IMAGE_TAG_PREFIX%__}"
+        if [[ -z "${WORKSPACE_TAG}" ]]; then
+            WORKSPACE_TAG="latest"
+        fi
+        WORKSPACE_IMAGE="${INPUTS_IMAGE_REPOSITORY_PREFIX}/${WORKSPACE_NAME}:${WORKSPACE_TAG}"
+
+        # Generate multi-stage Containerfile: staging collects all dist-dynamic dirs,
+        # final FROM scratch + single COPY produces exactly 1 layer (required by skopeo extraction)
+        CONTAINERFILE=$(mktemp /tmp/Containerfile.XXXXXX)
+        {
+            echo "FROM scratch AS staging"
+            for entry in "${exported_plugins[@]}"; do
+                entryPath="${entry%%:*}"
+                entryName="${entry##*:}"
+                echo "COPY ${entryPath}/dist-dynamic /staging/${entryName}/"
+            done
+            echo "FROM scratch"
+            echo "COPY --from=staging /staging/ /"
+        } > "$CONTAINERFILE"
+
+        echo "========== Building Workspace Bundle ${WORKSPACE_IMAGE} (${#exported_plugins[@]} plugins) =========="
+        cat "$CONTAINERFILE"
+        echo ""
+
+        if ${INPUTS_CONTAINER_BUILD_TOOL} build -f "$CONTAINERFILE" -t "${WORKSPACE_IMAGE}" .; then
+            if [[ "${INPUTS_PUSH_CONTAINER_IMAGE}" == "true" ]]
+            then
+                echo "========== Publishing Workspace Bundle ${WORKSPACE_IMAGE} =========="
+                if ${INPUTS_CONTAINER_BUILD_TOOL} push "${WORKSPACE_IMAGE}"; then
+                    images+=("${WORKSPACE_IMAGE}")
+                else
+                    echo " Error pushing workspace bundle image"
+                    errors+=("workspace-bundle:${WORKSPACE_NAME}")
+                fi
+            else
+                images+=("${WORKSPACE_IMAGE}")
+            fi
+        else
+            echo " Error building workspace bundle image"
+            errors+=("workspace-bundle:${WORKSPACE_NAME}")
+        fi
+
+        rm -f "$CONTAINERFILE"
+    fi
+
     if [[ ${#errors[@]} -gt 0 ]]; then
         echo "Plugins with failed exports: ${errors[*]}"
     fi

--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -33,10 +33,23 @@ fi
 # end TODO remove this once fully migrated to rhdh-cli
 ##########################################################
 
-# by default, run online with npx --yes installing the cli 
+# by default, run online with npx --yes installing the cli
 # use a local binary (for airgapped/hermetic use cases) with:
 # export INPUTS_CLI_CALLER=/path/to/node_modules/.bin/rhdh-cli
-INPUTS_CLI_CALLER=${INPUTS_CLI_CALLER:-"npx --yes ${INPUTS_CLI_PACKAGE}@${INPUTS_CLI_VERSION}"}
+#
+# Pin floating transitive deps of the CLI: npx resolves the CLI's dependency RANGES
+# fresh on every run, so pinning the CLI version alone does not give a reproducible
+# toolchain. @backstage/config-loader@1.11.0 (2026-07-14, inside the CLI's ^1.10.9
+# range) swapped the config-schema compiler to ts-json-schema-generator, which rejects
+# config.d.ts files importing source-only paths (e.g. backstage-plugin-theme <=0.14.9)
+# and broke previously-green exports. Installing the pin alongside the CLI makes npm
+# dedupe the CLI's own dependency to the pinned version.
+if [[ "${INPUTS_CLI_PACKAGE}" == "@red-hat-developer-hub/cli" ]]
+then
+    INPUTS_CLI_CALLER=${INPUTS_CLI_CALLER:-"npx --yes --package=@backstage/config-loader@1.10.12 --package=${INPUTS_CLI_PACKAGE}@${INPUTS_CLI_VERSION} -- rhdh-cli"}
+else
+    INPUTS_CLI_CALLER=${INPUTS_CLI_CALLER:-"npx --yes ${INPUTS_CLI_PACKAGE}@${INPUTS_CLI_VERSION}"}
+fi
 
 # Check local installation first, then fall back to npx --yes (requires network)
 run_cli() {
@@ -230,8 +243,15 @@ else
         popd > /dev/null
     done < "${INPUTS_PLUGINS_FILE}"
 
+    # Never publish a PARTIAL workspace bundle: the bundle tag represents the whole
+    # plugins-list, and pushing it with plugins missing silently overwrites the last
+    # complete bundle in the registry (this degraded live bundles on 2026-07-17).
+    if [[ "${INPUTS_BUNDLE_WORKSPACE}" == "true" ]] && [[ ${#errors[@]} -gt 0 ]] && [[ ${#exported_plugins[@]} -gt 0 ]]
+    then
+        echo "========== Skipping workspace bundle: ${#errors[@]} plugin export(s) failed — refusing to overwrite the last complete bundle with a partial one =========="
+    fi
     # Build workspace bundle image (all exported plugins in a single OCI image with 1 layer)
-    if [[ "${INPUTS_BUNDLE_WORKSPACE}" == "true" ]] && [[ "${INPUTS_IMAGE_REPOSITORY_PREFIX}" != "" ]] && [[ ${#exported_plugins[@]} -gt 0 ]]
+    if [[ "${INPUTS_BUNDLE_WORKSPACE}" == "true" ]] && [[ "${INPUTS_IMAGE_REPOSITORY_PREFIX}" != "" ]] && [[ ${#exported_plugins[@]} -gt 0 ]] && [[ ${#errors[@]} -eq 0 ]]
     then
         WORKSPACE_NAME=$(basename "${workspaceOverlayFolder}")
         # Strip trailing __ from tag prefix to get workspace-level tag (no per-plugin version)

--- a/override-sources/README.md
+++ b/override-sources/README.md
@@ -6,7 +6,7 @@ This GitHub Action applies patch files and source overlay files from a specified
 
 ```yaml
 - name: Override Sources
-  uses: redhat-developer/rhdh-plugin-export-utils/override-sources@main
+  uses: veecode-platform/devportal-plugin-export-utils/override-sources@main
   with:
     overlay-root: ${{ github.workspace }}/overlay-repo/workspaces/workspace-name
     workspace-root: .
@@ -52,7 +52,7 @@ This GitHub Action applies patch files and source overlay files from a specified
 
 ```yaml
 - name: Override Sources before building
-  uses: redhat-developer/rhdh-plugin-export-utils/override-sources@main
+  uses: veecode-platform/devportal-plugin-export-utils/override-sources@main
   with:
     overlay-root: ${{ github.workspace }}/overlay-repo/${{ inputs.overlay-root }}
     workspace-root: source-repo/${{ inputs.plugins-root }}
@@ -63,7 +63,7 @@ This GitHub Action applies patch files and source overlay files from a specified
     yarn install --immutable
 
 - name: Export dynamic plugins
-  uses: redhat-developer/rhdh-plugin-export-utils/export-dynamic@main
+  uses: veecode-platform/devportal-plugin-export-utils/export-dynamic@main
   with:
     # ... other inputs
 ``` 

--- a/validate-metadata/README.md
+++ b/validate-metadata/README.md
@@ -10,7 +10,7 @@ For each YAML file in the `metadata/` folder of the overlay workspace, the follo
 
 2. **Version Match**: The `version` field in the metadata matches the `version` field in the corresponding plugin's `package.json`
 
-3. **OCI Reference Validation** (if `dynamicArtifact` starts with `oci://ghcr.io`):
+3. **OCI Reference Validation** (if `dynamicArtifact` starts with `oci://`):
    - **Tag Format**: The image tag should be `bs_<target backstage version>__<plugin version>`
    - **Reference Format**: The image reference (without tag) should be `<image repository prefix>/<package name with @ and / replaced by ->`
 
@@ -25,7 +25,7 @@ For each YAML file in the `metadata/` folder of the overlay workspace, the follo
     overlay-root: ${{ github.workspace }}/overlay-repo/workspaces/my-workspace
     plugins-root: ${{ github.workspace }}/source-repo/workspaces/my-workspace
     target-backstage-version: 1.42.5
-    image-repository-prefix: ghcr.io/my-org/my-repo  # Optional
+    image-repository-prefix: quay.io/veecode  # Optional
 ```
 
 ## Inputs
@@ -141,7 +141,7 @@ npm install
 # Run validation (should pass)
 INPUTS_OVERLAY_ROOT="$(pwd)/test/cases/pass" \
 INPUTS_PLUGINS_ROOT="$(pwd)/test/source" \
-INPUTS_IMAGE_REPOSITORY_PREFIX="ghcr.io/test-org/test-repo" \
+INPUTS_IMAGE_REPOSITORY_PREFIX="quay.io/veecode" \
 INPUTS_TARGET_BACKSTAGE_VERSION="1.42.5" \
 node validate-metadata.ts
 ```

--- a/validate-metadata/README.md
+++ b/validate-metadata/README.md
@@ -20,7 +20,7 @@ For each YAML file in the `metadata/` folder of the overlay workspace, the follo
 
 ```yaml
 - name: Validate Catalog Metadata
-  uses: redhat-developer/rhdh-plugin-export-utils/validate-metadata@main
+  uses: veecode-platform/devportal-plugin-export-utils/validate-metadata@main
   with:
     overlay-root: ${{ github.workspace }}/overlay-repo/workspaces/my-workspace
     plugins-root: ${{ github.workspace }}/source-repo/workspaces/my-workspace

--- a/validate-metadata/action.yaml
+++ b/validate-metadata/action.yaml
@@ -32,6 +32,12 @@ outputs:
   validation-error-count:
     description: Number of validation errors found
     value: ${{ steps.validate.outputs.metadata-validation-error-count }}
+  metadata-warning-packages:
+    description: JSON array of coverage warnings ({kind, packageName, message}) — plugins exported by plugins-list.yaml with no matching metadata file
+    value: ${{ steps.validate.outputs.metadata-warning-packages }}
+  metadata-warning-count:
+    description: Number of coverage warnings
+    value: ${{ steps.validate.outputs.metadata-warning-count }}
 
 runs:
   using: composite

--- a/validate-metadata/action.yaml
+++ b/validate-metadata/action.yaml
@@ -40,4 +40,4 @@ runs:
         INPUTS_IMAGE_REPOSITORY_PREFIX: ${{ inputs.image-repository-prefix }}
       run: |
         npm install
-        node validate-metadata.ts
+        npx tsx validate-metadata.ts

--- a/validate-metadata/package-lock.json
+++ b/validate-metadata/package-lock.json
@@ -8,7 +8,497 @@
       "name": "validate-metadata",
       "version": "1.0.0",
       "dependencies": {
+        "tsx": "^4.19.2",
         "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
+      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/yaml": {

--- a/validate-metadata/package.json
+++ b/validate-metadata/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "tsx": "^4.19.2",
     "yaml": "^2.8.2"
   }
 }

--- a/validate-metadata/test/cases/pass/metadata/test-backend.yaml
+++ b/validate-metadata/test/cases/pass/metadata/test-backend.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions.backstage.io/v1alpha1
 kind: Package
 metadata:
   name: test-backend
-  namespace: rhdh
+  namespace: devportal
 spec:
   packageName: '@test-org/plugin-test-backend'
   dynamicArtifact: ./dynamic-plugins/dist/test-org-plugin-test-backend

--- a/validate-metadata/test/cases/pass/metadata/test-plugin.yaml
+++ b/validate-metadata/test/cases/pass/metadata/test-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions.backstage.io/v1alpha1
 kind: Package
 metadata:
   name: test-plugin
-  namespace: rhdh
+  namespace: devportal
 spec:
   packageName: '@test-org/plugin-test'
   dynamicArtifact: oci://ghcr.io/test-org/test-repo/test-org-plugin-test:bs_1.42.5__1.0.0!test-org-plugin-test

--- a/validate-metadata/validate-metadata.ts
+++ b/validate-metadata/validate-metadata.ts
@@ -360,34 +360,45 @@ function validateOciReference(
   packageName: string
 ): void {
   const { reference, tag } = parseOciReference(dynamicArtifact);
-  const expectedTag = `bs_${TARGET_BACKSTAGE_VERSION}__${pluginVersion}`;
 
-  if (tag !== expectedTag) {
+  // Accept two tag formats:
+  // - Individual plugin: bs_<backstage-version>__<plugin-version>
+  // - Workspace bundle: bs_<backstage-version>
+  const expectedIndividualTag = `bs_${TARGET_BACKSTAGE_VERSION}__${pluginVersion}`;
+  const expectedBundleTag = `bs_${TARGET_BACKSTAGE_VERSION}`;
+
+  if (tag !== expectedIndividualTag && tag !== expectedBundleTag) {
     errors.push({
       kind: 'mismatch',
       file: metadataFilePath,
       field: 'dynamicArtifact.tag',
-      expected: expectedTag,
+      expected: `${expectedIndividualTag} or ${expectedBundleTag}`,
       actual: tag,
-      message: `OCI tag mismatch: expected "${expectedTag}" but got "${tag}"`
+      message: `OCI tag mismatch: expected "${expectedIndividualTag}" or "${expectedBundleTag}" but got "${tag}"`
     });
   }
-  
-  // Validate reference format: <image-repository-prefix>/<package name with @ and / replaced by ->
+
+  // Validate reference format
   if (!IMAGE_REPOSITORY_PREFIX) {
     return;
   }
-  
+
+  // Accept two reference formats:
+  // - Individual: oci://<prefix>/<plugin-image-name>
+  // - Workspace bundle: oci://<prefix>/<workspace-name>
   const expectedImageName = packageNameToImageName(packageName);
-  const expectedReference = `oci://${IMAGE_REPOSITORY_PREFIX}/${expectedImageName}`;
-  if (reference !== expectedReference) {
+  const expectedIndividualRef = `oci://${IMAGE_REPOSITORY_PREFIX}/${expectedImageName}`;
+  const workspaceName = path.basename(OVERLAY_ROOT!);
+  const expectedBundleRef = `oci://${IMAGE_REPOSITORY_PREFIX}/${workspaceName}`;
+
+  if (reference !== expectedIndividualRef && reference !== expectedBundleRef) {
     errors.push({
       kind: 'mismatch',
       file: metadataFilePath,
       field: 'dynamicArtifact.reference',
-      expected: expectedReference,
+      expected: `${expectedIndividualRef} or ${expectedBundleRef}`,
       actual: reference,
-      message: `OCI reference mismatch: expected "${expectedReference}" but got "${reference}"`
+      message: `OCI reference mismatch: expected "${expectedIndividualRef}" or "${expectedBundleRef}" but got "${reference}"`
     });
   }
 }

--- a/validate-metadata/validate-metadata.ts
+++ b/validate-metadata/validate-metadata.ts
@@ -186,6 +186,11 @@ function reportErrorsAndExit(errors: ValidationError[], warnings: MissingMetadat
     fs.appendFileSync(githubOutput, `metadata-validation-errors=${errorsJson}\n`);
     fs.appendFileSync(githubOutput, `metadata-validation-passed=${errors.length === 0}\n`);
     fs.appendFileSync(githubOutput, `metadata-validation-error-count=${errors.length}\n`);
+    // The coverage warnings were computed and then discarded (summary-only).
+    // Exposing them lets downstream tooling grade a missing metadata file as a
+    // finding instead of scraping the step summary.
+    fs.appendFileSync(githubOutput, `metadata-warning-packages=${JSON.stringify(warnings)}\n`);
+    fs.appendFileSync(githubOutput, `metadata-warning-count=${warnings.length}\n`);
   }
 
   if (errors.length > 0) {

--- a/validate-metadata/validate-metadata.ts
+++ b/validate-metadata/validate-metadata.ts
@@ -336,7 +336,7 @@ function validateMetadataFile(metadataFilePath: string, pluginsMapping: Map<stri
   }
   
   // Validate dynamicArtifact if it's an OCI reference
-  if (dynamicArtifact?.startsWith('oci://ghcr.io')) {
+  if (dynamicArtifact?.startsWith('oci://')) {
     validateOciReference(errors, metadataFilePath, dynamicArtifact, pluginVersion, packageName);
   }
   
@@ -478,7 +478,7 @@ function packageNameToImageName(packageName: string): string {
 
 /**
  * Parse OCI reference into components
- * Format: oci://ghcr.io/<org>/<repo>/<name>:<tag>!<hash>
+ * Format: oci://<registry>/<path>/<name>:<tag>!<hash>
  */
 function parseOciReference(ociRef: string): OciReference {
   // Remove hash suffix if present


### PR DESCRIPTION
Part 1 of veecode-platform/veecode-drydock#53 (revised plan in the issue comment).

- `validate-metadata` now writes `metadata-warning-packages` (JSON array of `{kind, packageName, message}`) and `metadata-warning-count` to `GITHUB_OUTPUT`, wired as action outputs — same pattern as the three existing outputs. The warnings were already computed; they were just summary-only.
- `export-dynamic.yaml` publishes them as a per-workspace artifact `metadata warnings (<overlay-root>)`, the same naming convention as `dynamic plugin packages`. Content: `metadata-warnings.json` = `{ workspace, warnings }`.

Consumed by the Drydock gate (drydock side lands separately): a package exported by `plugins-list.yaml` with no metadata file becomes a graded, non-blocking finding instead of an invisible non-subject.

Also makes the awk-scraping of `GITHUB_STEP_SUMMARY` in overlays' `auto-publish-pr.yaml` obsolete once that path points at this fork's action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)