### PR TITLE
fix(workflows): checkout export-utils helpers via job_workflow_sha

### DIFF
--- a/.github/workflows/check-backstage-compatibility.yaml
+++ b/.github/workflows/check-backstage-compatibility.yaml
@@ -93,21 +93,13 @@ jobs:
           ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
-      - name: Resolve export-utils ref
-        id: export-utils-ref
-        run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
-          then
-            ref="${GITHUB_REF_NAME}"
-          fi
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-
+      # github.job_workflow_sha is this reusable workflow's commit — do not use
+      # GITHUB_WORKFLOW_REF (caller branch, e.g. overlays release-1.10). RHDHBUGS-3554
       - name: Checkout export-utils compatibility helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: redhat-developer/rhdh-plugin-export-utils
-          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          ref: ${{ github.job_workflow_sha }}
           path: _export-utils
           sparse-checkout: common/scripts/backstage-version-compatible.sh
           sparse-checkout-cone-mode: false

--- a/.github/workflows/export-workspaces-as-dynamic.yaml
+++ b/.github/workflows/export-workspaces-as-dynamic.yaml
@@ -149,21 +149,13 @@ jobs:
           ref: ${{ steps.set-overlay-repo-ref.outputs.OVERLAY_REPO_REF }}
           repository:  ${{ steps.set-overlay-repo.outputs.OVERLAY_REPO }}
 
-      - name: Resolve export-utils ref
-        id: export-utils-ref
-        run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
-          then
-            ref="${GITHUB_REF_NAME}"
-          fi
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-
+      # github.job_workflow_sha is this reusable workflow's commit — do not use
+      # GITHUB_WORKFLOW_REF (caller branch, e.g. overlays release-1.10). RHDHBUGS-3554
       - name: Checkout export-utils compatibility helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: redhat-developer/rhdh-plugin-export-utils
-          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          ref: ${{ github.job_workflow_sha }}
           path: _export-utils
           sparse-checkout: common/scripts/backstage-version-compatible.sh
           sparse-checkout-cone-mode: false

--- a/.github/workflows/update-plugins-repo-refs.yaml
+++ b/.github/workflows/update-plugins-repo-refs.yaml
@@ -71,21 +71,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Resolve export-utils ref
-        id: export-utils-ref
-        run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          if [[ -z "${ref}" || "${ref}" == "${GITHUB_WORKFLOW_REF}" ]]
-          then
-            ref="${GITHUB_REF_NAME}"
-          fi
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-
+      # github.job_workflow_sha is this reusable workflow's commit — do not use
+      # GITHUB_WORKFLOW_REF (caller branch, e.g. overlays release-1.10). RHDHBUGS-3554
       - name: Checkout export-utils compatibility helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: redhat-developer/rhdh-plugin-export-utils
-          ref: ${{ steps.export-utils-ref.outputs.ref }}
+          ref: ${{ github.job_workflow_sha }}
           path: _export-utils
           sparse-checkout: common/scripts/backstage-version-compatible.sh
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
## Summary
- Fix release-branch OCI publish Prepare failures caused by checking out a non-existent `release-*` ref from this repo
- Resolve compatibility-helper checkout with `github.job_workflow_sha` (same pattern as `export-dynamic.yaml`) instead of `GITHUB_WORKFLOW_REF` / caller branch
- Apply in `export-workspaces-as-dynamic`, `check-backstage-compatibility`, and `update-plugins-repo-refs`

Fixes RHDHBUGS-3554

## Test plan
- [ ] Re-run failed overlays release publish job after merge (or push to `release-1.10`) and confirm Prepare checks out helpers successfully
- [ ] Spot-check a `/publish` or compatibility workflow call from overlays still resolves helpers


Made with [Cursor](https://cursor.com)