### PR TITLE
feat: log backstage.features status during frontend plugin export (RHIDP-15708)

### DIFF
--- a/export-dynamic/export-dynamic.sh
+++ b/export-dynamic/export-dynamic.sh
@@ -161,6 +161,16 @@ else
                dist-dynamic/package.json > dist-dynamic/package.json.tmp \
                && mv dist-dynamic/package.json.tmp dist-dynamic/package.json
         fi
+
+        # Validate backstage.features for frontend plugins (NFS readiness)
+        if [[ "$pluginType" == "frontend" ]] && [[ -f "dist-dynamic/package.json" ]]; then
+            features=$(jq -c '.backstage.features // {}' dist-dynamic/package.json 2>/dev/null || echo '{}')
+            if [[ "$features" == "{}" || "$features" == "null" || -z "$features" ]]; then
+                echo "  ⚠️  backstage.features is missing or empty — plugin may not be NFS-ready"
+            else
+                echo "  ✅ backstage.features: $features"
+            fi
+        fi
         echo
 
         # package the dynamic plugin in a container image


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHIDP-15708

Adds inline backstage.features validation during the dynamic plugin export process.

 ### What

 After each frontend plugin is exported, the script checks dist-dynamic/package.json for the backstage.features field and logs the result:

 ```
     ✅ backstage.features: {"./alpha":"@backstage/FrontendPlugin"}
     ⚠️  backstage.features is missing or empty — plugin may not be NFS-ready
 ```

 This gives immediate visibility into NFS readiness in every export run's logs without requiring OCI artifact inspection after the fact.

 ### Behavior

 - Warn-only — does not fail the export. Plugins without backstage.features (e.g., those without standard Module Federation exports) continue to build and publish normally.
 - Once the NFS migration is complete ([RHDHPLAN-846](https://redhat.atlassian.net/browse/RHDHPLAN-846) hard cut-over), this can be upgraded to a hard failure with a one-line change.

 ### Why not hard-fail now?

 Many plugins don't have standard MF exports yet, so their backstage.features is legitimately empty. Hard-failing would block all exports for those plugins.

 ### Companion PR

 - redhat-developer/rhdh-plugin-export-overlays#3160 — adds NFS readiness dashboard and daily report workflow